### PR TITLE
Update Serial Driver to Support UART0

### DIFF
--- a/SerialDriver.cpp
+++ b/SerialDriver.cpp
@@ -178,7 +178,7 @@ void SerialDriver::show() {
         delayMicroseconds(DMX_MAB);
     }
 
-    SET_PERI_REG_MASK(UART_INT_ENA(1), UART_TXFIFO_EMPTY_INT_ENA);
+    SET_PERI_REG_MASK(UART_INT_ENA(SEROUT_UART), UART_TXFIFO_EMPTY_INT_ENA);
 
     startTime = micros();
 

--- a/SerialDriver.h
+++ b/SerialDriver.h
@@ -110,12 +110,12 @@ class SerialDriver {
 
     /* Returns number of bytes waiting in the TX FIFO of SEROUT_UART */
     static inline uint8_t getFifoLength() {
-        return (U1S >> USTXC) & 0xff;
+        return (ESP8266_REG(U0S+(0xF00*SEROUT_UART)) >> USTXC) & 0xff;
     }
 
     /* Append a byte to the TX FIFO of SEROUT_UART */
     static inline void enqueue(uint8_t byte) {
-        U1F = byte;
+        ESP8266_REG(U0F+(0xF00*SEROUT_UART)) = byte;
     }
 };
 


### PR DESCRIPTION
Fix to direct DMX traffic to serial0 (if desired). Allows for this Firmware to be used on a WEE Serial module (Xbee footprint) connected to a MiniRen8/4Xb.    (Note: first time using pull requests... )
