### PR TITLE
Fix Start Chanel >1, Add view stream test 

### DIFF
--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -510,26 +510,32 @@ void loop() {
                     seqTracker[uniOffset] = e131.packet->sequence_number + 1;
                 }
 
-                /* Offset the channel if required for the first universe */
+                /* Offset the channels if required */
                 uint16_t offset = 0;
-                if (e131.universe == config.universe)
-                    offset = config.channel_start - 1;
+                offset = config.channel_start - 1;
 
                 /* Find start of data based off the Universe */
-                uint16_t dataStart = uniOffset * UNIVERSE_LIMIT;
+                int16_t dataStart = uniOffset * UNIVERSE_LIMIT - offset;
 
-                /* Caculate how much data we need for this buffer */
+                /* Calculate how much data we need for this buffer */
                 uint16_t dataStop = config.channel_count;
                 if ((dataStart + UNIVERSE_LIMIT) < dataStop)
                     dataStop = dataStart + UNIVERSE_LIMIT;
 
                 /* Set the data */
                 uint16_t buffloc = 0;
+                
+                /* ignore data from start of first Universe before channel_start */
+                if(dataStart<0) {
+                    dataStart=0;
+                    buffloc=config.channel_start-1;
+                }
+                
                 for (int i = dataStart; i < dataStop; i++) {
     #if defined(ESPS_MODE_PIXEL)
-                    pixels.setValue(i, e131.data[buffloc + offset]);
+                    pixels.setValue(i, e131.data[buffloc]);
     #elif defined(ESPS_MODE_SERIAL)
-                    serial.setValue(i, e131.data[buffloc + offset]);
+                    serial.setValue(i, e131.data[buffloc]);
     #endif
                     buffloc++;
                 }

--- a/PixelDriver.cpp
+++ b/PixelDriver.cpp
@@ -285,3 +285,7 @@ void PixelDriver::show() {
         }
     }
 }
+
+uint8_t* PixelDriver::getData() {
+    return pixdata;
+}

--- a/PixelDriver.h
+++ b/PixelDriver.h
@@ -99,6 +99,7 @@ class PixelDriver {
     void setGamma(bool gamma);
     void updateOrder(PixelColor color);
     void show();
+    uint8_t* getData();
 
     /* Set channel value at address */
     inline void setValue(uint16_t address, uint8_t value) {

--- a/SerialDriver.cpp
+++ b/SerialDriver.cpp
@@ -186,3 +186,8 @@ void SerialDriver::show() {
     memcpy(_asyncdata, _serialdata, _size);
     std::swap(_asyncdata, _serialdata);
 }
+
+
+uint8_t* SerialDriver::getData() {
+    return _serialdata;
+}

--- a/SerialDriver.h
+++ b/SerialDriver.h
@@ -65,6 +65,7 @@ class SerialDriver {
             BaudRate baud);
     void startPacket();
     void show();
+    uint8_t* getData();
 
     /* Set the value */
     inline void setValue(uint16_t address, uint8_t value) {

--- a/html/index.html
+++ b/html/index.html
@@ -198,7 +198,7 @@
           <div class="form-group">
             <label class="control-label col-sm-2" for="t_mode">Testing Mode</label>
             <div class="col-sm-10">
-              <select class="form-control" id="tmode" name="tmode" onclick="test()">
+              <select class="form-control" id="tmode" name="tmode" onchange="test()">
                 <option value="t_disabled">Disabled</option>
                 <option value="t_static">Static</option>
                 <option value="t_chase">Chase</option>
@@ -215,8 +215,16 @@
             <div class="form-group">
               <label class="control-label col-sm-2" for="t_color">Color</label>
               <div class="col-sm-10">
-                <input type="button" class="form-control color no-alpha" value="rgb(255,255,255)" />
+                <input type="button" class="form-control color no-alpha" value="rgb(128,128,128)"/>
               </div>
+            </div>
+          </div>
+          
+          <!-- Testing - View Stream -->
+          <div id="t_view" class="tdiv hidden">
+            <legend class="esps-legend">View Stream</legend>
+            <div class="form-group">
+              <div class="col-sm-12"><canvas id="canvas" width="270" height="570"></canvas></div>
             </div>
           </div>
 

--- a/html/script.js
+++ b/html/script.js
@@ -115,6 +115,9 @@ $(function() {
         else 
             $('#s_baud').prop('disabled', false);
     });
+	
+	var canvas = document.getElementById("canvas");
+	ctx = canvas.getContext("2d");
 });
 
 // Page event feeds
@@ -144,39 +147,45 @@ function wsConnect() {
             feed();
         };
         
-        ws.onmessage = function (event) { 
-            var cmd = event.data.substr(0, 2);
-            var data = event.data.substr(2);
-            switch (cmd) {
-            case 'E1':
-                getElements(data);
-                break;                
-            case 'G1':
-                getConfig(data);
-                break;
-            case 'G2':
-                getConfigStatus(data);
-                break;
-            case 'S1':
-                setConfig(data);
-                reboot();
-                break;
-            case 'S2':
-                setConfig(data);
-                break;
-            case 'X1':
-                getRSSI(data);
-                break;
-            case 'X2':
-                getE131Status(data);
-                break;
-            case 'X6':
-                showReboot();
-                break;
-            default:
-                console.log('Unknown Command: ' + event.data);
-                break;
-            }
+        ws.onmessage = function (event) {
+		    if(typeof event.data === "string") {
+                var cmd = event.data.substr(0, 2);
+                var data = event.data.substr(2);
+                switch (cmd) {
+                case 'E1':
+                    getElements(data);
+                    break;                
+                case 'G1':
+                    getConfig(data);
+                    break;
+                case 'G2':
+                    getConfigStatus(data);
+                    break;
+                case 'S1':
+                    setConfig(data);
+                    reboot();
+                    break;
+                case 'S2':
+                    setConfig(data);
+                    break;
+                case 'X1':
+                    getRSSI(data);
+                    break;
+                case 'X2':
+                    getE131Status(data);
+                    break;
+                case 'X6':
+                    showReboot();
+                    break;
+                default:
+                    console.log('Unknown Command: ' + event.data);
+                    break;
+                }
+			} else {
+				steamData= new Uint8Array(event.data);
+				drawStream(steamData);
+				if (!$('#tmode option:selected').val().localeCompare('t_view')) ws.send('T4');
+			}
         };
         
         ws.onerror = function() {
@@ -189,6 +198,49 @@ function wsConnect() {
     } else {
         alert('WebSockets is NOT supported by your Browser! You will need to upgrade your browser or downgrade to v2.0 of the ESPixelStick firmware.');
     }
+}
+
+function drawStream(steamData) {
+	for (i = 0; i < steamData.length; i+=3) {
+		ctx.fillStyle='rgb(' + steamData[i+rOffset] + ',' + steamData[i+gOffset] + ',' + steamData[i+bOffset] + ')';
+		var col=(i/3)%25;
+		var row=Math.floor((i/3)/25);
+		ctx.fillRect(10+(col*10),10+(row*10),9,9);
+	}
+}
+
+function setColorOrder(colorOrder) {
+	switch (colorOrder) {
+	case 1: //GRB
+		rOffset = 1;
+		gOffset = 0;
+		bOffset = 2;
+		break;
+	case 2: //BRG
+		rOffset = 1;
+		gOffset = 2;
+		bOffset = 0;
+		break;
+	case 3: //RBG
+		rOffset = 0;
+		gOffset = 2;
+		bOffset = 1;
+		break;
+	case 4: //GBR
+		rOffset = 2;
+		gOffset = 0;
+		bOffset = 1;
+		break;
+	case 5: //BGR
+		rOffset = 2;
+		gOffset = 1;
+		bOffset = 0;
+		break;
+	default: //RGB
+		rOffset = 0;
+		gOffset = 1;
+		bOffset = 2;
+	}
 }
 
 function getElements(data) {
@@ -244,6 +296,8 @@ function getConfig(data) {
         $('#p_color').val(config.pixel.color);
         $('#p_gamma').prop('checked', config.pixel.gamma);
 		
+		setColorOrder(config.pixel.color);
+		
         // Trigger updated elements
         $('#p_type').trigger('click');
         $('#p_count').trigger('change');
@@ -255,6 +309,8 @@ function getConfig(data) {
         $('#s_count').val(config.e131.channel_count);
         $('#s_proto').val(config.serial.type);
         $('#s_baud').val(config.serial.baudrate);
+		
+		setColorOrder(0);
 
         // Trigger updated elements
         $('#s_proto').trigger('click');
@@ -354,6 +410,7 @@ function submitConfig() {
             }
         };
     ws.send('S2' + JSON.stringify(json));
+	setColorOrder(parseInt($('#p_color').val()));
 }
 
 function refreshPixel() {
@@ -398,6 +455,9 @@ function test() {
 
     if (!tmode.localeCompare('t_disabled')) {
         ws.send('T0');
+    }
+	if (!tmode.localeCompare('t_view')) {
+        ws.send('T4');
     }
 }
 

--- a/html/style.css
+++ b/html/style.css
@@ -82,6 +82,12 @@ body {
   width: 100%;
 }
 
+canvas {
+  background-color: black; 
+  width: 100%;
+  height: auto;
+}
+
 /* Snackbar - position it at the bottom and in the middle of the screen */
 #snackbar {
     visibility: hidden;     /* Hidden by default. Visible on click */

--- a/wshandler.h
+++ b/wshandler.h
@@ -161,7 +161,7 @@ void procT(uint8_t *data, AsyncWebSocketClient *client) {
         case '0':
             config.testmode = TestMode::DISABLED;
             break;
-        case '1':
+        case '1': {
             config.testmode = TestMode::STATIC;
             DynamicJsonBuffer jsonBuffer;
             JsonObject &json = jsonBuffer.parseObject(reinterpret_cast<char*>(data + 2));
@@ -183,6 +183,15 @@ void procT(uint8_t *data, AsyncWebSocketClient *client) {
 #endif
             }
             break;
+        }
+        case '4': {
+#if defined(ESPS_MODE_PIXEL)
+            client->binary(pixels.getData(),config.channel_count);
+#elif defined(ESPS_MODE_SERIAL)
+            client->binary(serial.getData(),config.channel_count);
+#endif
+            break;
+        }
     }
 }
 


### PR DESCRIPTION
main loop e131 to setValue code wasn't handling start channels > 1  correctly causing problems if the channel count spanned universes.

Added a view of current output onto the testing page for the view stream option (hopefully that was what you were expecting!). Initially started to send each universe separately (which was how the above bug was found) but found the ESPAsyncWebServer would cause exceptions under heavy work. Then realised the much easier way of sending the pixdata/_serialdata. Update speed is controlled by how fast the client can draw the screen