### PR TITLE
move globals to ESPixelstick.ino

### DIFF
--- a/ESPixelStick.h
+++ b/ESPixelStick.h
@@ -20,6 +20,13 @@
 #ifndef ESPIXELSTICK_H_
 #define ESPIXELSTICK_H_
 
+#include <ArduinoJson.h>
+
+/* Output Mode - There can be only one! (-Conor MacLeod) */
+#define ESPS_MODE_PIXEL
+//#define ESPS_MODE_SERIAL
+
+
 #if defined(ESPS_MODE_PIXEL)
 #include "PixelDriver.h"
 #elif defined(ESPS_MODE_SERIAL)
@@ -108,41 +115,10 @@ typedef struct {
 #endif
 } config_t;
 
-/* Globals */
-E131            e131;
-testing_t       testing;
-config_t        config;
-uint32_t        *seqError;      /* Sequence error tracking for each universe */
-uint16_t        uniLast = 1;    /* Last Universe to listen for */
-bool            reboot = false; /* Reboot flag */
-AsyncWebServer  web(HTTP_PORT); /* Web Server */
-AsyncWebSocket  ws("/ws");      /* Web Socket Plugin */
-
-/* Output Drivers */
-#if defined(ESPS_MODE_PIXEL)
-#include "PixelDriver.h"
-PixelDriver     pixels;         /* Pixel object */
-#elif defined(ESPS_MODE_SERIAL)
-#include "SerialDriver.h"
-SerialDriver    serial;         /* Serial object */
-#else
-#error "No valid output mode defined."
-#endif
-
 /* Forward Declarations */
 void serializeConfig(String &jsonString, bool pretty = false, bool creds = false);
 void dsNetworkConfig(JsonObject &json);
 void dsDeviceConfig(JsonObject &json);
 void saveConfig();
-
-/* Plain text friendly MAC */
-String getMacAddress() {
-    uint8_t mac[6];
-    char macStr[18] = {0};
-    WiFi.macAddress(mac);
-    snprintf(macStr, sizeof(macStr), "%02X:%02X:%02X:%02X:%02X:%02X",
-            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
-    return  String(macStr);
-}
 
 #endif /* ESPIXELSTICK_H_ */

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -23,8 +23,8 @@
 /*****************************************/
 
 /* Output Mode - There can be only one! (-Conor MacLeod) */
-#define ESPS_MODE_PIXEL
-//#define ESPS_MODE_SERIAL
+/* NOW MOVED TO ESPixelStick.h */
+
 
 /* Fallback configuration if config.json is empty or fails */
 const char ssid[] = "ENTER_SSID_HERE";
@@ -54,6 +54,27 @@ extern "C" {
 
 uint8_t             *seqTracker;        /* Current sequence numbers for each Universe */
 uint32_t            lastUpdate;         /* Update timeout tracker */
+
+/* Globals */
+E131            e131;
+testing_t       testing;
+config_t        config;
+uint32_t        *seqError;      /* Sequence error tracking for each universe */
+uint16_t        uniLast = 1;    /* Last Universe to listen for */
+bool            reboot = false; /* Reboot flag */
+AsyncWebServer  web(HTTP_PORT); /* Web Server */
+AsyncWebSocket  ws("/ws");      /* Web Socket Plugin */
+
+/* Output Drivers */
+#if defined(ESPS_MODE_PIXEL)
+#include "PixelDriver.h"
+PixelDriver     pixels;         /* Pixel object */
+#elif defined(ESPS_MODE_SERIAL)
+#include "SerialDriver.h"
+SerialDriver    serial;         /* Serial object */
+#else
+#error "No valid output mode defined."
+#endif
 
 /* Forward Declarations */
 void loadConfig();

--- a/html/index.html
+++ b/html/index.html
@@ -368,3 +368,4 @@
   </script>
 </body>
 </html>
+

--- a/html/script.js
+++ b/html/script.js
@@ -562,3 +562,4 @@ function reboot() {
     showReboot();
     ws.send('X6');
 }
+

--- a/wshandler.h
+++ b/wshandler.h
@@ -20,6 +20,22 @@
 #ifndef WSHANDLER_H_
 #define WSHANDLER_H_
 
+#include "ESPixelStick.h"
+
+#if defined (ESPS_MODE_PIXEL)
+            #include "PixelDriver.h"
+            extern PixelDriver     pixels;         /* Pixel object */
+#endif
+
+extern  E131            e131;
+extern  testing_t       testing;
+extern  config_t        config;
+extern  uint32_t        *seqError;  /* Sequence error tracking for each universe */
+extern  uint16_t        uniLast;    /* Last Universe to listen for */
+extern  bool            reboot;     /* Reboot flag */
+
+
+
 /* 
   Packet Commands
     E1 - Get Elements
@@ -132,7 +148,7 @@ void procG(uint8_t *data, AsyncWebSocketClient *client) {
             json["ssid"] = (String)WiFi.SSID();
             json["hostname"] = (String)WiFi.hostname();
             json["ip"] = WiFi.localIP().toString();
-            json["mac"] = getMacAddress();
+            json["mac"] = WiFi.macAddress();
             json["version"] = (String)VERSION;
             json["flashchipid"] = String(ESP.getFlashChipId(), HEX);
             json["usedflashsize"] = (String)ESP.getFlashChipSize();


### PR DESCRIPTION
As per #50 this makes it easier to add other functionality that might not be wanted in the main repository.
With these changes, its easier to include the structures and enums from ESPixelstick.h

Moved globals to ESPixelstick.ino
Moved ESPS_MODE to ESPixelstick.h
Updated wshandler.h to suit
removed getMacAddress - replaced with WiFi.macAddress()