### PR TITLE
fix AP fallback reboot loop

### DIFF
--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -136,7 +136,6 @@ void setup() {
 
     // Setup WiFi Handlers
     wifiConnectHandler = WiFi.onStationModeGotIP(onWifiConnect);
-    wifiDisconnectHandler = WiFi.onStationModeDisconnected(onWiFiDisconnect);
 
     // Setup MQTT Handlers
     if (config.mqtt) {
@@ -169,6 +168,8 @@ void setup() {
             ESP.restart();
         }
     }
+
+    wifiDisconnectHandler = WiFi.onStationModeDisconnected(onWiFiDisconnect);
 
     // Configure and start the web server
     initWeb();


### PR DESCRIPTION
Move the initialisation of the disconnect handler to _after_ the initial connection logic