### PR TITLE
Fix Websocket Lag

### DIFF
--- a/html/script.js
+++ b/html/script.js
@@ -348,10 +348,16 @@ function wsProcessQueue() {
     } else {
         //set wsBusy flag that we are waiting for a response
         wsBusy=true;
-        //set timeout to clear flag and try next message if response isn't recieved
-        wsTimerId=setTimeout(wsReadyToSend,2000);
-        //get next message from queue and send it.
+        //get next message from queue.
         message=wsQueue.shift();
+        //set timeout to clear flag and try next message if response isn't recieved. Short timeout for message types that don't generate a response.
+        if(['T0','T1','T2','T3','X6'].indexOf(message.substr(0,2))) {
+            timeout=40;
+        } else {
+            timeout=2000;
+        }
+        wsTimerId=setTimeout(wsReadyToSend,timeout);
+        //send it.
         console.log('WS sending ' + message);
         ws.send(message);
     }

--- a/wshandler.h
+++ b/wshandler.h
@@ -45,6 +45,9 @@ extern bool         reboot;     // Reboot flag
     
     T0 - Disable Testing
     T1 - Static Testing
+    T2 - Chase Test
+    T3 - Rainbow Test
+    T4 - View Stream
 
     S1 - Set Network Config
     S2 - Set Device Config
@@ -52,6 +55,7 @@ extern bool         reboot;     // Reboot flag
     X1 - Get RSSI
     X2 - Get E131 Status
     Xh - Get Heap
+    XU - Get Uptime
     X6 - Reboot
 */
 


### PR DESCRIPTION
#78 introduced an issue where ws requests that don't cause a response to be sent, notably requests related to testing modes, caused the queue to wait for a 2000ms timeout on a response that wasn't coming.

Updated the queue so those requests that don't expect a response just pause the queue for 40ms. This removes the lag and also stops the possibility of test messages being sent faster than they could be responded to - e.g. when swiping around the colour picker. The queue just maintains the latest message of each type so if multiple colour requests are generated in that 40ms it is just the latest one that gets sent when the timer expires.