### PR TITLE
MQTT: Don’t request a clean session on restart. Fixes #67.

### DIFF
--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -173,6 +173,9 @@ void setup() {
         mqtt.onDisconnect(onMqttDisconnect);
         mqtt.onMessage(onMqttMessage);
         mqtt.setServer(config.mqtt_ip.c_str(), config.mqtt_port);
+        // Unset clean session (defaults to true) so we get retained messages of QoS > 0
+        // FIXME: Make this configurable
+        mqtt.setCleanSession(false);
         if (config.mqtt_user.length() > 0)
             mqtt.setCredentials(config.mqtt_user.c_str(), config.mqtt_password.c_str());
     }


### PR DESCRIPTION
Shouldn’t have any adverse effects.
If the ESPixelStick status has been set with the retain flag and QoS > 0,
it will receive the last configuration from the broker upon reconnects,
thus being able to continue with any "home lighting" effects.

Fixes #67 without the need for local storage.