### PR TITLE
Smallfixes

### DIFF
--- a/ESPixelStick.h
+++ b/ESPixelStick.h
@@ -32,6 +32,8 @@ const char BUILD_DATE[] = __DATE__;
 #include <ESPAsyncTCP.h>
 #include <ESPAsyncUDP.h>
 #include <ESPAsyncWebServer.h>
+#include <ESPAsyncE131.h>
+#include <ArduinoJson.h>
 
 #if defined(ESPS_MODE_PIXEL)
 #include "PixelDriver.h"

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -902,5 +902,10 @@ void loop() {
     if (serial.canRefresh())
         serial.show();
 #endif
+
+// workaround crash - consume incoming bytes on serial port
+    if (LOG_PORT.available()) {
+        while (LOG_PORT.read() >= 0);
+    }
 }
 

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -29,15 +29,7 @@ const char passphrase[] = "ENTER_PASSPHRASE_HERE";
 /*         END - Configuration           */
 /*****************************************/
 
-#include <ESP8266WiFi.h>
-#include <Ticker.h>
-#include <AsyncMqttClient.h>
-#include <ESP8266mDNS.h>
-#include <ESPAsyncTCP.h>
-#include <ESPAsyncUDP.h>
-#include <ESPAsyncWebServer.h>
 #include <ESPAsyncE131.h>
-#include <ArduinoJson.h>
 #include <Hash.h>
 #include <SPI.h>
 #include "ESPixelStick.h"

--- a/wshandler.h
+++ b/wshandler.h
@@ -363,6 +363,8 @@ void handle_fw_upload(AsyncWebServerRequest *request, String filename,
                 String(efupdate.getError()));
 
     if (final) {
+        request->send(200, "text/plain", "Update Finished: " +
+                String(efupdate.getError()));
         LOG_PORT.println(F("* Upload Finished."));
         efupdate.end();
         SPIFFS.begin();


### PR DESCRIPTION
Send http 200 response on successful firmware upload
- scripted firmware uploads would hang curl

Workaround for ESP crash on receiving serial data
- accidentally typing characters to the ESP UART would crash it

Moved #includes files to .h Fixed compile error with ArduinoJson missing include
