### PR TITLE
Effects: Startup and Idle effect options 

### DIFF
--- a/ESPixelStick.h
+++ b/ESPixelStick.h
@@ -101,13 +101,13 @@ typedef struct {
     bool        ap_fallback;    /* Fallback to AP if fail to associate? */
 
     /* Effects */
-    String startup_effect_name;
-    CRGB startup_effect_color;
-    uint8_t startup_effect_brightness;
-    bool startup_effect_reverse;
-    bool startup_effect_mirror;
-    bool startup_effect_allleds;
-    bool startup_effect_enabled;
+    String effect_name;
+    CRGB effect_color;
+    uint8_t effect_brightness;
+    bool effect_reverse;
+    bool effect_mirror;
+    bool effect_allleds;
+    bool effect_enabled;
     bool effect_idleenabled;
     uint16_t effect_idletimeout;
 

--- a/ESPixelStick.h
+++ b/ESPixelStick.h
@@ -115,6 +115,7 @@ typedef struct {
     String      mqtt_user;
     String      mqtt_password;
     String      mqtt_topic;
+    bool        mqtt_clean;
 
     /* E131 */
     uint16_t    universe;       /* Universe to listen for */

--- a/ESPixelStick.h
+++ b/ESPixelStick.h
@@ -99,6 +99,15 @@ typedef struct {
     bool        dhcp;           /* Use DHCP? */
     bool        ap_fallback;    /* Fallback to AP if fail to associate? */
 
+    /* Effects */
+    String startup_effect_name;
+    CRGB startup_effect_color;
+    uint8_t startup_effect_brightness;
+    bool startup_effect_reverse;
+    bool startup_effect_mirror;
+    bool startup_effect_allleds;
+    bool startup_effect_enabled;
+
     /* MQTT */
     bool        mqtt;           /* Use MQTT? */
     String      mqtt_ip;
@@ -132,6 +141,7 @@ typedef struct {
 void serializeConfig(String &jsonString, bool pretty = false, bool creds = false);
 void dsNetworkConfig(JsonObject &json);
 void dsDeviceConfig(JsonObject &json);
+void dsEffectConfig(JsonObject &json);
 void saveConfig();
 
 void connectWifi();

--- a/ESPixelStick.h
+++ b/ESPixelStick.h
@@ -78,7 +78,8 @@ class DevCap {
 enum class DataSource : uint8_t {
     E131,
     MQTT,
-    WEB
+    WEB,
+    IDLEWEB
 };
 
 // Configuration structure
@@ -107,6 +108,9 @@ typedef struct {
     bool startup_effect_mirror;
     bool startup_effect_allleds;
     bool startup_effect_enabled;
+    bool effect_idleenabled;
+    uint16_t effect_idletimeout;
+
 
     /* MQTT */
     bool        mqtt;           /* Use MQTT? */
@@ -157,5 +161,7 @@ void publishRGBState();
 void publishRGBBrightness();
 void publishRGBColor();
 void setStatic(uint8_t r, uint8_t g, uint8_t b);
+void idleTimeout();
+
 
 #endif  // ESPIXELSTICK_H_

--- a/ESPixelStick.h
+++ b/ESPixelStick.h
@@ -62,7 +62,7 @@ const char BUILD_DATE[] = __DATE__;
 #define RDMNET_DNSSD_E133VERS   1
 
 // Configuration file params
-#define CONFIG_MAX_SIZE 2048    /* Sanity limit for config file */
+#define CONFIG_MAX_SIZE 4096    /* Sanity limit for config file */
 
 // Pixel Types
 class DevCap {

--- a/ESPixelStick.h
+++ b/ESPixelStick.h
@@ -107,7 +107,7 @@ typedef struct {
     bool effect_reverse;
     bool effect_mirror;
     bool effect_allleds;
-    bool effect_enabled;
+    bool effect_startenabled;
     bool effect_idleenabled;
     uint16_t effect_idletimeout;
 

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -609,10 +609,15 @@ void validateConfig() {
     }
 
     effects.setFromConfig();
-    if (config.effect_enabled) {
+    if (config.effect_startenabled) {
         if (effects.isValidEffect(config.effect_name)) {
             effects.setEffect(config.effect_name);
-            config.ds = DataSource::WEB;
+
+            if ( !config.effect_name.equalsIgnoreCase("disabled")
+              && !config.effect_name.equalsIgnoreCase("view") ) {
+                config.ds = DataSource::WEB;
+            }
+
         }
     } else {
         effects.setEffect("Disabled");
@@ -714,7 +719,7 @@ void dsEffectConfig(JsonObject &json) {
         config.effect_color = { effectsJson["r"], effectsJson["g"], effectsJson["b"] };
         if (effectsJson.containsKey("brightness"))
             config.effect_brightness = effectsJson["brightness"];
-        config.effect_enabled = effectsJson["enabled"];
+        config.effect_startenabled = effectsJson["startenabled"];
         config.effect_idleenabled = effectsJson["idleenabled"];
         config.effect_idletimeout = effectsJson["idletimeout"];
 
@@ -844,7 +849,7 @@ void serializeConfig(String &jsonString, bool pretty, bool creds) {
     _effects["b"] = config.effect_color.b;
 
     _effects["brightness"] = config.effect_brightness;
-    _effects["enabled"] = config.effect_enabled;
+    _effects["startenabled"] = config.effect_startenabled;
     _effects["idleenabled"] = config.effect_idleenabled;
     _effects["idletimeout"] = config.effect_idletimeout;
 

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -159,7 +159,7 @@ void setup() {
         effects.run();
     }
     // set the effect idle timer
-   idleTicker.attach(config.effect_idletimeout, idleTimeout);
+    idleTicker.attach(config.effect_idletimeout, idleTimeout);
 
     pixels.show();
 #else
@@ -609,9 +609,9 @@ void validateConfig() {
     }
 
     effects.setFromConfig();
-    if (config.startup_effect_enabled) {
-        if (effects.isValidEffect(config.startup_effect_name)) {
-            effects.setEffect(config.startup_effect_name);
+    if (config.effect_enabled) {
+        if (effects.isValidEffect(config.effect_name)) {
+            effects.setEffect(config.effect_name);
             config.ds = DataSource::WEB;
         }
     } else {
@@ -707,14 +707,14 @@ void dsEffectConfig(JsonObject &json) {
     // Effects
     if (json.containsKey("effects")) {
         JsonObject& effectsJson = json["effects"];
-        config.startup_effect_name = effectsJson["name"].as<String>();
-        config.startup_effect_mirror = effectsJson["mirror"];
-        config.startup_effect_allleds = effectsJson["allleds"];
-        config.startup_effect_reverse = effectsJson["reverse"];
-        config.startup_effect_color = { effectsJson["r"], effectsJson["g"], effectsJson["b"] };
+        config.effect_name = effectsJson["name"].as<String>();
+        config.effect_mirror = effectsJson["mirror"];
+        config.effect_allleds = effectsJson["allleds"];
+        config.effect_reverse = effectsJson["reverse"];
+        config.effect_color = { effectsJson["r"], effectsJson["g"], effectsJson["b"] };
         if (effectsJson.containsKey("brightness"))
-            config.startup_effect_brightness = effectsJson["brightness"];
-        config.startup_effect_enabled = effectsJson["enabled"];
+            config.effect_brightness = effectsJson["brightness"];
+        config.effect_enabled = effectsJson["enabled"];
         config.effect_idleenabled = effectsJson["idleenabled"];
         config.effect_idletimeout = effectsJson["idletimeout"];
 
@@ -764,6 +764,8 @@ void dsDeviceConfig(JsonObject &json) {
 void loadConfig() {
     // Zeroize Config struct
     memset(&config, 0, sizeof(config));
+
+    effects.setFromDefaults();
 
     // Load CONFIG_FILE json. Create and init with defaults if not found
     File file = SPIFFS.open(CONFIG_FILE, "r");
@@ -831,18 +833,18 @@ void serializeConfig(String &jsonString, bool pretty, bool creds) {
 
     // Effects
     JsonObject &_effects = json.createNestedObject("effects");
-    _effects["name"] = config.startup_effect_name;
+    _effects["name"] = config.effect_name;
 
-    _effects["mirror"] = config.startup_effect_mirror;
-    _effects["allleds"] = config.startup_effect_allleds;
-    _effects["reverse"] = config.startup_effect_reverse;
+    _effects["mirror"] = config.effect_mirror;
+    _effects["allleds"] = config.effect_allleds;
+    _effects["reverse"] = config.effect_reverse;
 
-    _effects["r"] = config.startup_effect_color.r;
-    _effects["g"] = config.startup_effect_color.g;
-    _effects["b"] = config.startup_effect_color.b;
+    _effects["r"] = config.effect_color.r;
+    _effects["g"] = config.effect_color.g;
+    _effects["b"] = config.effect_color.b;
 
-    _effects["brightness"] = config.startup_effect_brightness;
-    _effects["enabled"] = config.startup_effect_enabled;
+    _effects["brightness"] = config.effect_brightness;
+    _effects["enabled"] = config.effect_enabled;
     _effects["idleenabled"] = config.effect_idleenabled;
     _effects["idletimeout"] = config.effect_idletimeout;
 

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -419,7 +419,7 @@ void publishState() {
     color["g"] = effects.getColor().g;
     color["b"] = effects.getColor().b;
     root["brightness"] = effects.getBrightness();
-    if (effects.getEffect() != nullptr) {
+    if (effects.getEffect() != "") {
         root["effect"] = effects.getEffect();
     }
     root["reverse"] = effects.getReverse();

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -486,6 +486,13 @@ void initWeb() {
         request->send(404, "text/plain", "Page not found");
     });
 
+    DefaultHeaders::Instance().addHeader(F("Access-Control-Allow-Origin"), "*");
+
+    // Config file upload handler
+    web.on("/config", HTTP_POST, [](AsyncWebServerRequest *request) {
+        ws.textAll("X6");
+    }, handle_config_upload);
+
     web.begin();
 
     LOG_PORT.print(F("- Web Server started on port "));
@@ -525,7 +532,6 @@ void validateConfig() {
 
 #if defined(ESPS_MODE_PIXEL)
     // Set Mode
-//    config.devmode = DevMode::MPIXEL;
     config.devmode.MPIXEL = true;
     config.devmode.MSERIAL = false;
 
@@ -556,7 +562,6 @@ void validateConfig() {
     }
 #elif defined(ESPS_MODE_SERIAL)
     // Set Mode
-//    config.devmode = DevMode::MSERIAL;
     config.devmode.MPIXEL = false;
     config.devmode.MSERIAL = true;
 
@@ -575,6 +580,13 @@ void validateConfig() {
     else if (config.baudrate < BaudRate::BR_38400)
         config.baudrate = BaudRate::BR_57600;
 #endif
+
+    if (config.startup_effect_enabled) {
+        if (effects.isValidEffect(config.startup_effect_name)) {
+            effects.setFromConfig();
+            config.ds = DataSource::WEB;
+        }
+    }
 }
 
 void updateConfig() {
@@ -654,6 +666,22 @@ void dsNetworkConfig(JsonObject &json) {
     }
 }
 
+// De-serialize Effect Config
+void dsEffectConfig(JsonObject &json) {
+    // Effects
+    if (json.containsKey("effects")) {
+        JsonObject& effectsJson = json["effects"];
+        config.startup_effect_name = effectsJson["name"].as<String>();
+        config.startup_effect_mirror = effectsJson["mirror"];
+        config.startup_effect_allleds = effectsJson["allleds"];
+        config.startup_effect_reverse = effectsJson["reverse"];
+        config.startup_effect_color = { effectsJson["r"], effectsJson["g"], effectsJson["b"] };
+        if (effectsJson.containsKey("brightness"))
+            config.startup_effect_brightness = effectsJson["brightness"];
+        config.startup_effect_enabled = effectsJson["enabled"];
+    }
+}
+
 // De-serialize Device Config
 void dsDeviceConfig(JsonObject &json) {
     // Device
@@ -721,6 +749,7 @@ void loadConfig() {
 
         dsNetworkConfig(json);
         dsDeviceConfig(json);
+        dsEffectConfig(json);
 
         LOG_PORT.println(F("- Configuration loaded."));
     }
@@ -756,6 +785,21 @@ void serializeConfig(String &jsonString, bool pretty, bool creds) {
     }
     network["dhcp"] = config.dhcp;
     network["ap_fallback"] = config.ap_fallback;
+
+    // Effects
+    JsonObject &_effects = json.createNestedObject("effects");
+    _effects["name"] = config.startup_effect_name;
+
+    _effects["mirror"] = config.startup_effect_mirror;
+    _effects["allleds"] = config.startup_effect_allleds;
+    _effects["reverse"] = config.startup_effect_reverse;
+
+    _effects["r"] = config.startup_effect_color.r;
+    _effects["g"] = config.startup_effect_color.g;
+    _effects["b"] = config.startup_effect_color.b;
+
+    _effects["brightness"] = config.startup_effect_brightness;
+    _effects["enabled"] = config.startup_effect_enabled;
 
     // MQTT
     JsonObject &_mqtt = json.createNestedObject("mqtt");

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -65,9 +65,6 @@ const char MQTT_SET_COMMAND_TOPIC[] = "/set";
 const char LIGHT_ON[] = "ON";
 const char LIGHT_OFF[] = "OFF";
 
-// MQTT json buffer size
-const int JSON_BUFFER_SIZE = JSON_OBJECT_SIZE(10);
-
 // Configuration file
 const char CONFIG_FILE[] = "/config.json";
 
@@ -369,7 +366,8 @@ void onMqttDisconnect(AsyncMqttClientDisconnectReason reason) {
 
 void onMqttMessage(char* topic, char* payload,
         AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total) {
-    StaticJsonBuffer<JSON_BUFFER_SIZE> jsonBuffer;
+    DynamicJsonBuffer jsonBuffer;
+
     JsonObject& root = jsonBuffer.parseObject(payload);
     bool stateOn = false;
 
@@ -432,7 +430,7 @@ void onMqttMessage(char* topic, char* payload,
 }
 
 void publishState() {
-    StaticJsonBuffer<JSON_BUFFER_SIZE> jsonBuffer;
+    DynamicJsonBuffer jsonBuffer;
     JsonObject& root = jsonBuffer.createObject();
     root["state"] = (config.ds == DataSource::MQTT) ? LIGHT_ON : LIGHT_OFF;
     JsonObject& color = root.createNestedObject("color");

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -159,9 +159,7 @@ void setup() {
         effects.run();
     }
     // set the effect idle timer
-    if ( (config.effect_idleenabled) && (config.ds == DataSource::E131) ) {
-       idleTicker.attach(config.effect_idletimeout, idleTimeout);
-    }
+   idleTicker.attach(config.effect_idletimeout, idleTimeout);
 
     pixels.show();
 #else
@@ -906,7 +904,8 @@ void saveConfig() {
 }
 
 void idleTimeout() {
-    if (config.ds == DataSource::E131) {
+   idleTicker.attach(config.effect_idletimeout, idleTimeout);
+    if ( (config.effect_idleenabled) && (config.ds == DataSource::E131) ) {
         config.ds = DataSource::IDLEWEB;
         effects.setFromConfig();
     }
@@ -931,11 +930,9 @@ void loop() {
     if ( (config.ds == DataSource::E131) || (config.ds == DataSource::IDLEWEB) ) {
             // Parse a packet and update pixels
             if (!e131.isEmpty()) {
+                idleTicker.attach(config.effect_idletimeout, idleTimeout);
                 if (config.ds == DataSource::IDLEWEB) {
                     config.ds = DataSource::E131;
-                    if (config.effect_idleenabled) {
-                        idleTicker.attach(config.effect_idletimeout, idleTimeout);
-                    }
                 }
 
                 e131.pull(&packet);

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -175,6 +175,8 @@ void setup() {
         mqtt.onDisconnect(onMqttDisconnect);
         mqtt.onMessage(onMqttMessage);
         mqtt.setServer(config.mqtt_ip.c_str(), config.mqtt_port);
+        // Unset clean session (defaults to true) so we get retained messages of QoS > 0
+        mqtt.setCleanSession(config.mqtt_clean);
         if (config.mqtt_user.length() > 0)
             mqtt.setCredentials(config.mqtt_user.c_str(), config.mqtt_password.c_str());
     }
@@ -831,7 +833,7 @@ void serializeConfig(String &jsonString, bool pretty, bool creds) {
     _mqtt["user"] = config.mqtt_user.c_str();
     _mqtt["password"] = config.mqtt_password.c_str();
     _mqtt["topic"] = config.mqtt_topic.c_str();
-    _mqtt["clean"] = config.mqtt_topic.clean;
+    _mqtt["clean"] = config.mqtt_clean;
 
     // E131
     JsonObject &e131 = json.createNestedObject("e131");

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -639,30 +639,34 @@ void updateConfig() {
 
 // De-Serialize Network config
 void dsNetworkConfig(JsonObject &json) {
-    // Fallback to embedded ssid and passphrase if null in config
-    config.ssid = json["network"]["ssid"].as<String>();
-    if (!config.ssid.length())
-        config.ssid = ssid;
+    if (json.containsKey("network")) {
+        JsonObject& networkJson = json["network"];
 
-    config.passphrase = json["network"]["passphrase"].as<String>();
-    if (!config.passphrase.length())
-        config.passphrase = passphrase;
+        // Fallback to embedded ssid and passphrase if null in config
+        config.ssid = networkJson["ssid"].as<String>();
+        if (!config.ssid.length())
+            config.ssid = ssid;
 
-    // Network
-    for (int i = 0; i < 4; i++) {
-        config.ip[i] = json["network"]["ip"][i];
-        config.netmask[i] = json["network"]["netmask"][i];
-        config.gateway[i] = json["network"]["gateway"][i];
-    }
-    config.dhcp = json["network"]["dhcp"];
-    config.ap_fallback = json["network"]["ap_fallback"];
+        config.passphrase = networkJson["passphrase"].as<String>();
+        if (!config.passphrase.length())
+            config.passphrase = passphrase;
 
-    // Generate default hostname if needed
-    config.hostname = json["network"]["hostname"].as<String>();
-    if (!config.hostname.length()) {
-        char chipId[7] = { 0 };
-        snprintf(chipId, sizeof(chipId), "%06x", ESP.getChipId());
-        config.hostname = "esps-" + String(chipId);
+        // Network
+        for (int i = 0; i < 4; i++) {
+            config.ip[i] = networkJson["ip"][i];
+            config.netmask[i] = networkJson["netmask"][i];
+            config.gateway[i] = networkJson["gateway"][i];
+        }
+        config.dhcp = networkJson["dhcp"];
+        config.ap_fallback = networkJson["ap_fallback"];
+
+        // Generate default hostname if needed
+        config.hostname = networkJson["hostname"].as<String>();
+        if (!config.hostname.length()) {
+            char chipId[7] = { 0 };
+            snprintf(chipId, sizeof(chipId), "%06x", ESP.getChipId());
+            config.hostname = "esps-" + String(chipId);
+        }
     }
 }
 

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -603,16 +603,19 @@ void validateConfig() {
         config.baudrate = BaudRate::BR_57600;
 #endif
 
+    if (config.effect_idletimeout == 0) {
+        config.effect_idletimeout = 10;
+        config.effect_idleenabled = false;
+    }
+
     effects.setFromConfig();
     if (config.startup_effect_enabled) {
         if (effects.isValidEffect(config.startup_effect_name)) {
             effects.setEffect(config.startup_effect_name);
             config.ds = DataSource::WEB;
         }
-    }
-
-    if (config.effect_idletimeout == 0) {
-        config.effect_idleenabled = false;
+    } else {
+        effects.setEffect("Disabled");
     }
 
 }
@@ -647,10 +650,11 @@ void updateConfig() {
     pixels.begin(config.pixel_type, config.pixel_color, config.channel_count / 3);
     pixels.setGamma(config.gamma);
     updateGammaTable(config.gammaVal, config.briteVal);
-
     effects.begin(&pixels, config.channel_count / 3);
+
 #elif defined(ESPS_MODE_SERIAL)
     serial.begin(&SEROUT_PORT, config.serial_type, config.channel_count, config.baudrate);
+
 #endif
 
     LOG_PORT.print(F("- Listening for "));

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -378,6 +378,11 @@ void onMqttMessage(char* topic, char* payload,
         return;
     }
 
+// if its a retained message and we want clean session, ignore it
+    if ( properties.retain && config.mqtt_clean ) {
+        return;
+    }
+
     if (root.containsKey("state")) {
         if (strcmp(root["state"], LIGHT_ON) == 0) {
             stateOn = true;

--- a/EffectEngine.cpp
+++ b/EffectEngine.cpp
@@ -32,22 +32,27 @@ const EffectDesc EFFECT_LIST[] = {
 
 EffectEngine::EffectEngine() {
     // Initialize with defaults
-    setEffect(DEFAULT_EFFECT_NAME);
-    setColor(DEFAULT_EFFECT_COLOR);
-    setBrightness(DEFAULT_EFFECT_BRIGHTNESS);
-    setReverse(DEFAULT_EFFECT_REVERSE);
-    setMirror(DEFAULT_EFFECT_MIRROR);
-    setAllLeds(DEFAULT_EFFECT_ALLLEDS);
+    setFromDefaults();
+}
+
+void EffectEngine::setFromDefaults() {
+    config.effect_name = DEFAULT_EFFECT_NAME;
+    config.effect_color = DEFAULT_EFFECT_COLOR;
+    config.effect_brightness = DEFAULT_EFFECT_BRIGHTNESS;
+    config.effect_reverse = DEFAULT_EFFECT_REVERSE;
+    config.effect_mirror = DEFAULT_EFFECT_MIRROR;
+    config.effect_allleds = DEFAULT_EFFECT_ALLLEDS;
+    setFromConfig();
 }
 
 void EffectEngine::setFromConfig() {
     // Initialize with defaults
-    setEffect(config.startup_effect_name);
-    setColor(config.startup_effect_color);
-    setBrightness(config.startup_effect_brightness);
-    setReverse(config.startup_effect_reverse);
-    setMirror(config.startup_effect_mirror);
-    setAllLeds(config.startup_effect_allleds);
+    setEffect(config.effect_name);
+    setColor(config.effect_color);
+    setBrightness(config.effect_brightness);
+    setReverse(config.effect_reverse);
+    setMirror(config.effect_mirror);
+    setAllLeds(config.effect_allleds);
 }
 
 void EffectEngine::begin(DRIVER* ledDriver, uint16_t ledCount) {

--- a/EffectEngine.cpp
+++ b/EffectEngine.cpp
@@ -23,8 +23,8 @@ const EffectDesc EFFECT_LIST[] = {
 };
 
 // Effect defaults
-#define DEFAULT_EFFECT_NAME "Solid"
-#define DEFAULT_EFFECT_COLOR { 255, 255, 255 }
+#define DEFAULT_EFFECT_NAME "Disabled"
+#define DEFAULT_EFFECT_COLOR { 183, 0, 255 }
 #define DEFAULT_EFFECT_BRIGHTNESS 255
 #define DEFAULT_EFFECT_REVERSE false
 #define DEFAULT_EFFECT_MIRROR false

--- a/EffectEngine.cpp
+++ b/EffectEngine.cpp
@@ -67,12 +67,10 @@ void EffectEngine::run() {
     }
 }
 
-//void EffectEngine::setEffect(const char* effectName) {
-void EffectEngine::setEffect(const String effectNameStr) {
-    const char* effectName = effectNameStr.c_str();
+void EffectEngine::setEffect(const String effectName) {
     const uint8_t effectCount = sizeof(EFFECT_LIST) / sizeof(EffectDesc);
     for (uint8_t effect = 0; effect < effectCount; effect++) {
-        if (strcmp(effectName, EFFECT_LIST[effect].name) == 0) {
+        if (effectName == EFFECT_LIST[effect].name) {
             if (_activeEffect != &EFFECT_LIST[effect]) {
                 _activeEffect = &EFFECT_LIST[effect];
                 _effectTimeout = 0;
@@ -98,11 +96,10 @@ const EffectDesc* EffectEngine::getEffectInfo(unsigned a) {
     return &EFFECT_LIST[a];
 }
 
-bool EffectEngine::isValidEffect(const String effectNameStr) {
-    const char* effectName = effectNameStr.c_str();
+bool EffectEngine::isValidEffect(const String effectName) {
     const uint8_t effectCount = sizeof(EFFECT_LIST) / sizeof(EffectDesc);
     for (uint8_t effect = 0; effect < effectCount; effect++) {
-        if (strcmp(effectName, EFFECT_LIST[effect].name) == 0) {
+        if (effectName == EFFECT_LIST[effect].name) {
             return true;
         }
     }

--- a/EffectEngine.cpp
+++ b/EffectEngine.cpp
@@ -338,7 +338,7 @@ uint16_t EffectEngine::effectBreathe() {
 dCHSV EffectEngine::rgb2hsv(CRGB in_int)
 {
     dCHSV       out;
-    dCRGB       in = {in_int.r, in_int.g, in_int.b};
+    dCRGB       in = {in_int.r/255.0d, in_int.g/255.0d, in_int.b/255.0d};
     double      min, max, delta;
 
     min = in.r < in.g ? in.r : in.g;

--- a/EffectEngine.cpp
+++ b/EffectEngine.cpp
@@ -70,7 +70,7 @@ void EffectEngine::run() {
 void EffectEngine::setEffect(const String effectName) {
     const uint8_t effectCount = sizeof(EFFECT_LIST) / sizeof(EffectDesc);
     for (uint8_t effect = 0; effect < effectCount; effect++) {
-        if (effectName == EFFECT_LIST[effect].name) {
+        if ( effectName.equalsIgnoreCase(EFFECT_LIST[effect].name) ) {
             if (_activeEffect != &EFFECT_LIST[effect]) {
                 _activeEffect = &EFFECT_LIST[effect];
                 _effectTimeout = 0;

--- a/EffectEngine.h
+++ b/EffectEngine.h
@@ -41,6 +41,12 @@ typedef uint16_t (EffectEngine::*EffectFunc)(void);
 struct EffectDesc {
     const char* name;
     EffectFunc  func;
+    const char* htmlid;
+    bool        hasColor;
+    bool        hasMirror;
+    bool        hasReverse;
+    bool        hasAllLeds;
+    const char* wsTCode;
 };
 
 class EffectEngine {
@@ -69,7 +75,7 @@ public:
     void begin(DRIVER* ledDriver, uint16_t ledCount);
     void run();
 
-    const char* getEffect()                 { return _activeEffect ? _activeEffect->name : nullptr; }
+    String getEffect()                      { return _activeEffect ? _activeEffect->name : nullptr; }
     bool getReverse()                       { return _effectReverse; }
     bool getMirror()                        { return _effectMirror; }
     bool getAllLeds()                       { return _effectAllLeds; }
@@ -77,7 +83,11 @@ public:
     uint16_t getSpeed()                     { return _effectSpeed; }
     CRGB getColor()                         { return _effectColor; }
 
-    void setEffect(const char* effectName);
+    int getEffectCount();
+    const EffectDesc* getEffectInfo(unsigned a);
+    void setFromConfig();
+    bool isValidEffect(const String effectName);
+    void setEffect(const String effectName);
     void setReverse(bool reverse)           { _effectReverse = reverse; }
     void setMirror(bool mirror)             { _effectMirror = mirror; }
     void setAllLeds(bool allleds)            { _effectAllLeds = allleds; }
@@ -87,13 +97,14 @@ public:
 
     // Effect functions
     uint16_t effectSolidColor();
-    uint16_t effectRainbowCycle();
+    uint16_t effectRainbow();
     uint16_t effectChase();
     uint16_t effectBlink();
     uint16_t effectFlash();
     uint16_t effectFireFlicker();
     uint16_t effectLightning();
     uint16_t effectBreathe();
+    uint16_t effectNull();
     void clearAll();
 
 private:

--- a/EffectEngine.h
+++ b/EffectEngine.h
@@ -39,7 +39,7 @@ struct dCHSV {
 */
 typedef uint16_t (EffectEngine::*EffectFunc)(void);
 struct EffectDesc {
-    const char* name;
+    String      name;
     EffectFunc  func;
     const char* htmlid;
     bool        hasColor;
@@ -75,7 +75,7 @@ public:
     void begin(DRIVER* ledDriver, uint16_t ledCount);
     void run();
 
-    String getEffect()                      { return _activeEffect ? _activeEffect->name : nullptr; }
+    String getEffect()                      { return _activeEffect ? _activeEffect->name : ""; }
     bool getReverse()                       { return _effectReverse; }
     bool getMirror()                        { return _effectMirror; }
     bool getAllLeds()                       { return _effectAllLeds; }

--- a/EffectEngine.h
+++ b/EffectEngine.h
@@ -86,6 +86,8 @@ public:
     int getEffectCount();
     const EffectDesc* getEffectInfo(unsigned a);
     void setFromConfig();
+    void setFromDefaults();
+
     bool isValidEffect(const String effectName);
     void setEffect(const String effectName);
     void setReverse(bool reverse)           { _effectReverse = reverse; }

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ light:
       - Breathe
 ```
 
+Here's an example using the mosquitto_pub command line tool:
+```
+mosquitto_pub -t porch/esps/set -m '{"state":"ON","color":{"r":255,"g":128,"b":64},"brightness":255,"effect":"solid","reverse":false,"mirror":false}'
+```
+
 Resources
 ---------
 - Firmware: [http://github.com/forkineye/ESPixelStick](http://github.com/forkineye/ESPixelStick)

--- a/html/index.html
+++ b/html/index.html
@@ -234,9 +234,9 @@
             <label class="control-label col-sm-2" for="mqtt_topic">Topic</label>
             <div class="col-sm-10"><input type="text" class="form-control" id="mqtt_topic" name="mqtt_topic" placeholder="Enter Top Level MQTT Topic"></div>
           </div>
-          <div class="form-group">
+          <div class="form-group mqtt">
             <div class="col-sm-offset-2 col-sm-10">
-              <div class="checkbox"><label><input type="checkbox" id="mqtt_clean" name="mqtt_clean"> Clean MQTT on startup</label></div>
+              <div class="checkbox"><label><input type="checkbox" id="mqtt_clean" name="mqtt_clean"> Clean Session</label></div>
             </div>
           </div>
 

--- a/html/index.html
+++ b/html/index.html
@@ -234,6 +234,11 @@
             <label class="control-label col-sm-2" for="mqtt_topic">Topic</label>
             <div class="col-sm-10"><input type="text" class="form-control" id="mqtt_topic" name="mqtt_topic" placeholder="Enter Top Level MQTT Topic"></div>
           </div>
+          <div class="form-group">
+            <div class="col-sm-offset-2 col-sm-10">
+              <div class="checkbox"><label><input type="checkbox" id="mqtt_clean" name="mqtt_clean"> Clean MQTT on startup</label></div>
+            </div>
+          </div>
 
           <!-- Device Config Save -->
           <div class="form-group">

--- a/html/index.html
+++ b/html/index.html
@@ -292,10 +292,20 @@
                 <div class="checkbox"><label><input type="checkbox" id="t_startenabled" name="t_startenabled"> Enable Startup Effect</label></div>
               </div>
             </div>
+            <div class="form-group">
+              <div class="col-sm-offset-2 col-sm-10">
+                <div class="checkbox"><label><input type="checkbox" id="t_idleenabled" name="t_idleenabled"> Enable Idle Effect</label></div>
+              </div>
+            </div>
+            <div class="form-group" id="fg_udpport">
+              <label class="control-label col-sm-2" for="ssid">Idle Timeout</label>
+              <div class="col-sm-10"><input type="text" class="form-control" id="t_idletimeout" name="t_idletimeout" placeholder="Idle Timer (secs)"></div>
+            </div>
+
           </div>
           <div class="form-group t_startup">
             <div class="col-sm-offset-2 col-sm-10">
-              <button type="button" onclick="submitStartupEffect()" class="btn btn-primary">Set Startup</button>
+              <button type="button" onclick="submitStartupEffect()" class="btn btn-primary">Save Changes</button>
             </div>
           </div>
 

--- a/html/index.html
+++ b/html/index.html
@@ -5,6 +5,10 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title id="title"></title>
+<!-- for local development
+  <link rel="stylesheet" type="text/css" href="css/bootstrap.css">
+  <link rel="stylesheet" type="text/css" href="style.css">
+-->
   <link rel="stylesheet" type="text/css" href="esps.css">
 </head>
 
@@ -249,131 +253,44 @@
           <div class="form-group">
             <label class="control-label col-sm-2" for="t_mode">Testing Mode</label>
             <div class="col-sm-10">
-              <select class="form-control" id="tmode" name="tmode" onchange="test()">
-                <option value="t_disabled">Disabled</option>
-                <option value="t_static">Static</option>
-                <option value="t_blink">Blink</option>
-                <option value="t_flash">Flash</option>
-                <option value="t_chase">Chase</option>
-                <option value="t_rainbow">Rainbow</option>
-                <option value="t_fireflicker">Fire flicker</option>
-                <option value="t_lightning">Lightning</option>
-                <option value="t_breathe">Breathe</option>
-                <option value="t_view">View Stream</option>
+              <select class="form-control" id="tmode" name="tmode" onchange="effectChanged()">
               </select>
             </div>
           </div>
           <div id="t_disable"></div>
 
-          <!-- Testing - Static -->
-          <div id="t_static" class="tdiv hidden">
-            <legend class="esps-legend">Static Testing</legend>
+          <!-- Effect Options -->
+          <div id="t_options">
+            <legend class="esps-legend">Effect Options</legend>
             <div class="form-group">
-              <label class="control-label col-sm-2" for="t_color">Color</label>
-              <div class="col-sm-10">
-                <input type="button" class="form-control color no-alpha" value="rgb(128,128,128)"/>
+              <label class="control-label col-sm-2" id="lab_color" for="t_color">Color</label>
+              <div class="col-sm-10" id="div_color">
+                <input type="button" id="t_color" class="form-control color no-alpha" value="rgb(255,255,255)" />
+              </div>
+              <div class="col-sm-offset-2 col-sm-10" id="div_reverse">
+                <div class="checkbox"><label><input type="checkbox" id="t_reverse" class="reverse" name="t_reverse">Reverse pattern</label></div>
+              </div>
+              <div class="col-sm-offset-2 col-sm-10" id="div_mirror">
+                <div class="checkbox"><label><input type="checkbox" id="t_mirror" class="mirror" name="t_mirror">Mirror pattern</label></div>
+              </div>
+              <div class="col-sm-offset-2 col-sm-10" id="div_allleds">
+                <div class="checkbox"><label><input type="checkbox" id="t_allleds" class="allleds" name="t_allleds">All leds same </label></div>
               </div>
             </div>
           </div>
 
-          <!-- Testing - Blink -->
-          <div id="t_blink" class="tdiv hidden">
-            <legend class="esps-legend">Blink Testing</legend>
+          <!-- Startup Effect Config -->
+          <div class="t_startup">
+            <legend class="esps-legend">Startup Effect</legend>
             <div class="form-group">
-              <label class="control-label col-sm-2" for="t_color">Color</label>
-              <div class="col-sm-10">
-                <input type="button" class="form-control color no-alpha" value="rgb(128,128,128)"/>
+              <div class="col-sm-offset-2 col-sm-10">
+                <div class="checkbox"><label><input type="checkbox" id="t_startenabled" name="t_startenabled"> Enable Startup Effect</label></div>
               </div>
             </div>
           </div>
-
-          <!-- Testing - Flash -->
-          <div id="t_flash" class="tdiv hidden">
-            <legend class="esps-legend">Flash Testing</legend>
-            <div class="form-group">
-              <label class="control-label col-sm-2" for="t_color">Color</label>
-              <div class="col-sm-10">
-                <input type="button" class="form-control color no-alpha" value="rgb(128,128,128)"/>
-              </div>
-            </div>
-          </div>
-
-          <!-- Testing - Chase -->
-          <div id="t_chase" class="tdiv hidden">
-            <legend class="esps-legend">Chase Testing</legend>
-            <div class="form-group">
-              <label class="control-label col-sm-2" for="t_color">Color</label>
-              <div class="col-sm-10">
-                <input type="button" class="form-control color no-alpha" value="rgb(255,255,255)" />
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="control-label col-sm-2" for="t_reverse">Reverse</label>
-              <div class="col-sm-10">
-                <input type="checkbox" class="reverse" name="t_reverse">
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="control-label col-sm-2" for="t_mirror">Mirror</label>
-              <div class="col-sm-10">
-                <input type="checkbox" class="mirror" name="t_mirror">
-              </div>
-            </div>
-          </div>
-
-          <!-- Testing - Rainbow -->
-          <div id="t_rainbow" class="tdiv hidden">
-            <legend class="esps-legend">Rainbow Testing</legend>
-            <div class="form-group">
-              <label class="control-label col-sm-2" for="t_reverse">Reverse</label>
-              <div class="col-sm-10">
-                <input type="checkbox" class="reverse" name="t_reverse">
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="control-label col-sm-2" for="t_mirror">Mirror</label>
-              <div class="col-sm-10">
-                <input type="checkbox" class="mirror" name="t_mirror">
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="control-label col-sm-2" for="t_allleds">All Leds</label>
-              <div class="col-sm-10">
-                <input type="checkbox" class="allleds" name="t_allleds">
-              </div>
-            </div>
-          </div>
-
-          <!-- Testing - Fire flicker -->
-          <div id="t_fireflicker" class="tdiv hidden">
-            <legend class="esps-legend">Fire flicker Testing</legend>
-            <div class="form-group">
-              <label class="control-label col-sm-2" for="t_color">Color</label>
-              <div class="col-sm-10">
-                <input type="button" class="form-control color no-alpha" value="rgb(255,63,0)"/>
-              </div>
-            </div>
-          </div>
-
-          <!-- Testing - Lightning -->
-          <div id="t_lightning" class="tdiv hidden">
-            <legend class="esps-legend">Lightning Testing</legend>
-            <div class="form-group">
-              <label class="control-label col-sm-2" for="t_color">Color</label>
-              <div class="col-sm-10">
-                <input type="button" class="form-control color no-alpha" value="rgb(255,255,255)"/>
-              </div>
-            </div>
-          </div>
-
-          <!-- Testing - Breathe -->
-          <div id="t_breathe" class="tdiv hidden">
-            <legend class="esps-legend">Breathe Testing</legend>
-            <div class="form-group">
-              <label class="control-label col-sm-2" for="t_color">Color</label>
-              <div class="col-sm-10">
-                <input type="button" class="form-control color no-alpha" value="rgb(255,255,255)"/>
-              </div>
+          <div class="form-group t_startup">
+            <div class="col-sm-offset-2 col-sm-10">
+              <button type="button" onclick="submitStartupEffect()" class="btn btn-primary">Set Startup</button>
             </div>
           </div>
 
@@ -381,7 +298,7 @@
           <div id="t_view" class="tdiv hidden">
             <legend class="esps-legend">View Stream</legend>
             <div class="form-group">
-              <label class="control-label col-sm-2" for="t_color">Display</label>
+              <label class="control-label col-sm-2">Display</label>
               <div class="col-sm-10">
                 <div class="btn-group" data-toggle="buttons">
                   <label class="btn btn-primary">
@@ -496,6 +413,12 @@
     </div>
   </footer>
 
+  <!-- for local development
+  <script type="text/javascript" src="js/jquery-3.1.1.js"></script>
+  <script type="text/javascript" src="js/bootstrap.js"></script>
+  <script type="text/javascript" src="js/jqColorPicker.js"></script>
+  <script type="text/javascript" src="script.js"></script>
+  -->
   <script type="text/javascript" src="esps.js"></script>
 
   <script>

--- a/html/script.js
+++ b/html/script.js
@@ -753,7 +753,7 @@ function submitStartupEffect() {
                 'b': temp[3],
                 'brightness': 255,
                 'enabled': $('#t_startenabled').prop('checked'),
-                'idleenabled': $('#t_idleenabled'),
+                'idleenabled': $('#t_idleenabled').prop('checked'),
                 'idletimeout': parseInt($('#t_idletimeout').val())
 
             }

--- a/html/script.js
+++ b/html/script.js
@@ -203,6 +203,11 @@ $(function() {
     ctx = canvas.getContext("2d");
     ctx.font = "20px Arial";
     ctx.textAlign = "center";
+
+    // autoload tab based on URL hash
+    var hash = window.location.hash;
+    hash && $('ul.navbar-nav li a[href="' + hash + '"]').click();
+
 });
 
 function wifiValidation() {

--- a/html/script.js
+++ b/html/script.js
@@ -508,6 +508,7 @@ function getConfig(data) {
     $('#mqtt_user').val(config.mqtt.user);
     $('#mqtt_password').val(config.mqtt.password);
     $('#mqtt_topic').val(config.mqtt.topic);
+    $('#mqtt_clean').prop('checked', config.mqtt.clean);
 
     // E1.31 Config
     $('#universe').val(config.e131.universe);
@@ -701,7 +702,8 @@ function submitConfig() {
                 'port': $('#mqtt_port').val(),
                 'user': $('#mqtt_user').val(),
                 'password': $('#mqtt_password').val(),
-                'topic': $('#mqtt_topic').val()
+                'topic': $('#mqtt_topic').val(),
+                'clean': $('#mqtt_clean').prop('checked')
             },
             'e131': {
                 'universe': parseInt($('#universe').val()),

--- a/html/script.js
+++ b/html/script.js
@@ -614,6 +614,9 @@ function getEffectInfo(data) {
     $('#t_mirror').prop('checked', running.mirror);
     $('#t_allleds').prop('checked', running.allleds);
     $('#t_startenabled').prop('checked', running.enabled);
+    $('#t_idleenabled').prop('checked', running.idleenabled);
+    $('#t_idletimeout').val(running.idletimeout);
+
 }
 
 function getSystemStatus(data) {
@@ -749,7 +752,10 @@ function submitStartupEffect() {
                 'g': temp[2],
                 'b': temp[3],
                 'brightness': 255,
-                'enabled': $('#t_startenabled').prop('checked')
+                'enabled': $('#t_startenabled').prop('checked'),
+                'idleenabled': $('#t_idleenabled'),
+                'idletimeout': parseInt($('#t_idletimeout').val())
+
             }
         };
 

--- a/html/script.js
+++ b/html/script.js
@@ -339,17 +339,8 @@ function wsConnect() {
                 case 'XS':
                     getSystemStatus(data);
                     break;
-                case 'X1':
-                    getRSSI(data);
-                    break;
                 case 'X2':
                     getE131Status(data);
-                    break;
-                case 'Xh':
-                    getHeap(data);
-                    break;
-                case 'XU':
-                    getUptime(data);
                     break;
                 case 'X6':
                     showReboot();
@@ -640,36 +631,6 @@ function getSystemStatus(data) {
 
 // function getUptime
     var date = new Date(+status[2]);
-    var str = '';
-
-    str += Math.floor(date.getTime()/86400000) + " days, ";
-    str += ("0" + date.getUTCHours()).slice(-2) + ":";
-    str += ("0" + date.getUTCMinutes()).slice(-2) + ":";
-    str += ("0" + date.getUTCSeconds()).slice(-2);
-    $('#x_uptime').text(str);
-}
-
-function getRSSI(data) {
-    var rssi = +data;
-    var quality = 2 * (rssi + 100);
-
-    if (rssi <= -100)
-        quality = 0;
-    else if (rssi >= -50)
-        quality = 100;
-
-    $('#x_rssi').text(rssi);
-    $('#x_quality').text(quality);
-}
-
-function getHeap(data) {
-    var heap = +data;
-
-    $('#x_freeheap').text(heap);
-}
-
-function getUptime(data) {
-    var date = new Date(+data);
     var str = '';
 
     str += Math.floor(date.getTime()/86400000) + " days, ";

--- a/html/script.js
+++ b/html/script.js
@@ -613,7 +613,7 @@ function getEffectInfo(data) {
     $('#t_reverse').prop('checked', running.reverse);
     $('#t_mirror').prop('checked', running.mirror);
     $('#t_allleds').prop('checked', running.allleds);
-    $('#t_startenabled').prop('checked', running.enabled);
+    $('#t_startenabled').prop('checked', running.startenabled);
     $('#t_idleenabled').prop('checked', running.idleenabled);
     $('#t_idletimeout').val(running.idletimeout);
 
@@ -752,7 +752,7 @@ function submitStartupEffect() {
                 'g': temp[2],
                 'b': temp[3],
                 'brightness': 255,
-                'enabled': $('#t_startenabled').prop('checked'),
+                'startenabled': $('#t_startenabled').prop('checked'),
                 'idleenabled': $('#t_idleenabled').prop('checked'),
                 'idletimeout': parseInt($('#t_idletimeout').val())
 

--- a/html/script.js
+++ b/html/script.js
@@ -599,6 +599,7 @@ function getEffectInfo(data) {
 //  console.log (effectInfo.t_chase);
 
     // process the effect configuration options
+    $('#tmode').empty(); // clear the dropdown first
     for (var i in effectInfo) {
         var htmlid = effectInfo[i].htmlid;
         var name =   effectInfo[i].name;

--- a/wshandler.h
+++ b/wshandler.h
@@ -449,7 +449,7 @@ void handle_config_upload(AsyncWebServerRequest *request, String filename,
             LOG_PORT.println(reinterpret_cast<char*>(confuploadtemp));
             request->send(500, "text/plain", "Config Update Error." );
         } else {
-//          dsNetworkConfig(json);
+            dsNetworkConfig(json);
 //          dsDeviceConfig(json);
             dsEffectConfig(json);
             saveConfig();

--- a/wshandler.h
+++ b/wshandler.h
@@ -62,10 +62,7 @@ extern const char CONFIG_FILE[];
     S3 - Set Effect Startup Config
 
     XS - Get RSSI:heap:uptime
-    X1 - Get RSSI
     X2 - Get E131 Status
-    Xh - Get Heap
-    XU - Get Uptime
     X6 - Reboot
 */
 
@@ -81,9 +78,6 @@ void procX(uint8_t *data, AsyncWebSocketClient *client) {
                      (String)ESP.getFreeHeap() + ":" +
                      (String)millis());
             break;
-        case '1':
-            client->text("X1" + (String)WiFi.RSSI());
-            break;
         case '2': {
             uint32_t seqErrors = 0;
             for (int i = 0; i < ((uniLast + 1) - config.universe); i++)
@@ -96,12 +90,6 @@ void procX(uint8_t *data, AsyncWebSocketClient *client) {
                     e131.stats.last_clientIP.toString());
             break;
         }
-        case 'h':
-            client->text("Xh" + (String)ESP.getFreeHeap());
-            break;
-        case 'U':
-            client->text("XU" + (String)millis());
-            break;
         case '6':  // Init 6 baby, reboot!
             reboot = true;
     }

--- a/wshandler.h
+++ b/wshandler.h
@@ -187,7 +187,7 @@ void procG(uint8_t *data, AsyncWebSocketClient *client) {
             effect["reverse"] = effects.getReverse();
             effect["mirror"] = effects.getMirror();
             effect["allleds"] = effects.getAllLeds();
-            effect["enabled"] = config.startup_effect_enabled;
+            effect["enabled"] = config.effect_enabled;
             effect["idleenabled"] = config.effect_idleenabled;
             effect["idletimeout"] = config.effect_idletimeout;
 

--- a/wshandler.h
+++ b/wshandler.h
@@ -250,7 +250,9 @@ void procS(uint8_t *data, AsyncWebSocketClient *client) {
 }
 
 void procT(uint8_t *data, AsyncWebSocketClient *client) {
-    config.ds = DataSource::WEB;
+    // T9 is view stream, DONT change source when we get this
+    if ( (data[1] >= '1') && (data[1] <= '8') ) config.ds = DataSource::WEB;
+
     switch (data[1]) {
         case '0': { // Clear whole string
             //TODO: Store previous data source when effect is selected so we can switch back to it

--- a/wshandler.h
+++ b/wshandler.h
@@ -188,6 +188,9 @@ void procG(uint8_t *data, AsyncWebSocketClient *client) {
             effect["mirror"] = effects.getMirror();
             effect["allleds"] = effects.getAllLeds();
             effect["enabled"] = config.startup_effect_enabled;
+            effect["idleenabled"] = config.effect_idleenabled;
+            effect["idletimeout"] = config.effect_idletimeout;
+
 
 // dump all the known effect and options
             JsonObject &effectList = json.createNestedObject("effectList");

--- a/wshandler.h
+++ b/wshandler.h
@@ -187,7 +187,7 @@ void procG(uint8_t *data, AsyncWebSocketClient *client) {
             effect["reverse"] = effects.getReverse();
             effect["mirror"] = effects.getMirror();
             effect["allleds"] = effects.getAllLeds();
-            effect["enabled"] = config.effect_enabled;
+            effect["startenabled"] = config.effect_startenabled;
             effect["idleenabled"] = config.effect_idleenabled;
             effect["idletimeout"] = config.effect_idletimeout;
 

--- a/wshandler.h
+++ b/wshandler.h
@@ -36,6 +36,7 @@ extern uint32_t     *seqError;  // Sequence error tracking for each universe
 extern uint16_t     uniLast;    // Last Universe to listen for
 extern bool         reboot;     // Reboot flag
 
+extern const char CONFIG_FILE[];
 
 /*
   Packet Commands
@@ -43,6 +44,7 @@ extern bool         reboot;     // Reboot flag
 
     G1 - Get Config
     G2 - Get Config Status
+    G3 - Get Current Effect and Effect Config Options
 
     T0 - Disable Testing
     T1 - Static Testing
@@ -57,6 +59,7 @@ extern bool         reboot;     // Reboot flag
 
     S1 - Set Network Config
     S2 - Set Device Config
+    S3 - Set Effect Startup Config
 
     XS - Get RSSI:heap:uptime
     X1 - Get RSSI
@@ -67,6 +70,8 @@ extern bool         reboot;     // Reboot flag
 */
 
 EFUpdate efupdate;
+uint8_t * WSframetemp;
+uint8_t * confuploadtemp;
 
 void procX(uint8_t *data, AsyncWebSocketClient *client) {
     switch (data[1]) {
@@ -155,7 +160,8 @@ void procG(uint8_t *data, AsyncWebSocketClient *client) {
             client->text("G1" + response);
             break;
         }
-        case '2':
+
+        case '2': {
             // Create buffer and root object
             DynamicJsonBuffer jsonBuffer;
             JsonObject &json = jsonBuffer.createObject();
@@ -171,7 +177,19 @@ void procG(uint8_t *data, AsyncWebSocketClient *client) {
             json["realflashsize"] = (String)ESP.getFlashChipRealSize();
             json["freeheap"] = (String)ESP.getFreeHeap();
 
-            JsonObject &effect = json.createNestedObject("effect");
+            String response;
+            json.printTo(response);
+            client->text("G2" + response);
+            break;
+        }
+
+        case '3': {
+            String response;
+            DynamicJsonBuffer jsonBuffer;
+            JsonObject &json = jsonBuffer.createObject();
+
+// dump the current running effect options
+            JsonObject &effect = json.createNestedObject("currentEffect");
             effect["name"] = (String)effects.getEffect() ? effects.getEffect() : "";
             effect["brightness"] = effects.getBrightness();
             effect["speed"] = effects.getSpeed();
@@ -180,11 +198,29 @@ void procG(uint8_t *data, AsyncWebSocketClient *client) {
             effect["b"] = effects.getColor().b;
             effect["reverse"] = effects.getReverse();
             effect["mirror"] = effects.getMirror();
+            effect["allleds"] = effects.getAllLeds();
+            effect["enabled"] = config.startup_effect_enabled;
 
-            String response;
+// dump all the known effect and options
+            JsonObject &effectList = json.createNestedObject("effectList");
+            for(int i=0; i < effects.getEffectCount(); i++){
+                JsonObject &effect = effectList.createNestedObject( effects.getEffectInfo(i)->htmlid );
+                effect["name"] = effects.getEffectInfo(i)->name;
+                effect["htmlid"] = effects.getEffectInfo(i)->htmlid;
+                effect["hasColor"] = effects.getEffectInfo(i)->hasColor;
+                effect["hasMirror"] = effects.getEffectInfo(i)->hasMirror;
+                effect["hasReverse"] = effects.getEffectInfo(i)->hasReverse;
+                effect["hasAllLeds"] = effects.getEffectInfo(i)->hasAllLeds;
+                effect["wsTCode"] = effects.getEffectInfo(i)->wsTCode;
+//            effect["brightness"] = effects.getBrightness();
+//            effect["speed"] = effects.getSpeed();
+            }
+
             json.printTo(response);
-            client->text("G2" + response);
+            client->text("G3" + response);
+//LOG_PORT.print(response);
             break;
+        }
     }
 }
 
@@ -197,6 +233,7 @@ void procS(uint8_t *data, AsyncWebSocketClient *client) {
         return;
     }
 
+    bool reboot = false;
     switch (data[1]) {
         case '1':   // Set Network Config
             dsNetworkConfig(json);
@@ -205,7 +242,6 @@ void procS(uint8_t *data, AsyncWebSocketClient *client) {
             break;
         case '2':   // Set Device Config
             // Reboot if MQTT changed
-            bool reboot = false;
             if (config.mqtt != json["mqtt"]["enabled"])
                 reboot = true;
 
@@ -216,6 +252,11 @@ void procS(uint8_t *data, AsyncWebSocketClient *client) {
                 client->text("S1");
             else
                 client->text("S2");
+            break;
+        case '3':   // Set Effect Startup Config
+            dsEffectConfig(json);
+            saveConfig();
+            client->text("S3");
             break;
     }
 }
@@ -374,6 +415,52 @@ void handle_fw_upload(AsyncWebServerRequest *request, String filename,
         SPIFFS.begin();
         saveConfig();
         reboot = true;
+    }
+}
+
+void handle_config_upload(AsyncWebServerRequest *request, String filename,
+        size_t index, uint8_t *data, size_t len, bool final) {
+    static File file;
+    if (!index) {
+        WiFiUDP::stopAll();
+        LOG_PORT.print(F("* Config Upload Started: "));
+        LOG_PORT.println(filename.c_str());
+
+        if (confuploadtemp) {
+          free (confuploadtemp);
+          confuploadtemp = nullptr;
+        }
+        confuploadtemp = (uint8_t*) malloc(CONFIG_MAX_SIZE);
+    }
+
+    LOG_PORT.printf("index %d len %d\n", index, len);
+    memcpy(confuploadtemp + index, data, len);
+    confuploadtemp[index + len] = 0;
+
+    if (final) {
+        int filesize = index+len;
+        LOG_PORT.print(F("* Config Upload Finished:"));
+        LOG_PORT.printf(" %d bytes", filesize);
+
+        DynamicJsonBuffer jsonBuffer;
+        JsonObject &json = jsonBuffer.parseObject(reinterpret_cast<char*>(confuploadtemp));
+        if (!json.success()) {
+            LOG_PORT.println(F("*** Parse Error ***"));
+            LOG_PORT.println(reinterpret_cast<char*>(confuploadtemp));
+            request->send(500, "text/plain", "Config Update Error." );
+        } else {
+//          dsNetworkConfig(json);
+//          dsDeviceConfig(json);
+            dsEffectConfig(json);
+            saveConfig();
+            request->send(200, "text/plain", "Config Update Finished: " );
+//          reboot = true;
+        }
+
+        if (confuploadtemp) {
+            free (confuploadtemp);
+            confuploadtemp = nullptr;
+        }
     }
 }
 


### PR DESCRIPTION
Added Startup Effect save options to web UI
- Loading and Saving to config.json
- enable effects on reboot (if enabled)
- added config upload suuport
- implemented S3 to save startup effect
- implement G3 to servce up effect config information
- moved current effect from G2 to G3 (along with effect info)

effect dropdown selector now works instantly

Removed testing_modes from html
- now uses the json info from the server

Changed default columns in Viewer to sqrt(num_leds)