### PR TITLE
Led grouping and zigzag support

### DIFF
--- a/ESPixelStick.h
+++ b/ESPixelStick.h
@@ -132,6 +132,8 @@ typedef struct {
     /* Pixels */
     PixelType   pixel_type;     /* Pixel type */
     PixelColor  pixel_color;    /* Pixel color order */
+    GroupMode   groupMode;	/* disabled, grouped, zigzag */
+    uint16_t    groupSize;
     bool        gamma;          /* Use gamma map? */
     float       gammaVal;       /* gamma value to use */
     float       briteVal;       /* brightness lto use */

--- a/EffectEngine.cpp
+++ b/EffectEngine.cpp
@@ -63,10 +63,10 @@ void EffectEngine::begin(DRIVER* ledDriver, uint16_t ledCount) {
 
 void EffectEngine::run() {
     if (_initialized && _activeEffect && _activeEffect->func) {
-        uint32_t now = millis();
-        if (now > _effectTimeout) {
+        if (millis() - _effectLastRun >= _effectDelay) {
+            _effectLastRun = millis();
             uint16_t delay = (this->*_activeEffect->func)();
-            _effectTimeout = now + max((int)delay, MIN_EFFECT_DELAY);
+            _effectDelay = max((int)delay, MIN_EFFECT_DELAY);
             _effectCounter++;
         }
     }
@@ -78,7 +78,8 @@ void EffectEngine::setEffect(const String effectName) {
         if ( effectName.equalsIgnoreCase(EFFECT_LIST[effect].name) ) {
             if (_activeEffect != &EFFECT_LIST[effect]) {
                 _activeEffect = &EFFECT_LIST[effect];
-                _effectTimeout = 0;
+                _effectLastRun = millis();
+                _effectDelay = MIN_EFFECT_DELAY;
                 _effectCounter = 0;
                 _effectStep = 0;
             }

--- a/EffectEngine.h
+++ b/EffectEngine.h
@@ -52,9 +52,11 @@ struct EffectDesc {
 class EffectEngine {
 
 private:
+    using timeType = decltype(millis());
 
     const EffectDesc* _activeEffect = nullptr;      /* Pointer to the active effect descriptor */
-    uint32_t _effectTimeout         = 0;            /* Time after which the effect will run again */
+    uint32_t _effectDelay           = 0;            /* How long to wait for the effect to run again */
+    timeType _effectLastRun         = 0;            /* When did the effect last run ? in millis() */
     uint32_t _effectCounter         = 0;            /* Counter for the number of calls to the active effect */
     uint16_t _effectSpeed           = 1024;         /* Externally controlled effect speed [MIN_EFFECT_DELAY, MAX_EFFECT_DELAY]*/
     bool _effectReverse             = false;        /* Externally controlled effect reverse option */

--- a/PixelDriver.cpp
+++ b/PixelDriver.cpp
@@ -257,15 +257,47 @@ void ICACHE_RAM_ATTR PixelDriver::show() {
     if (!pixdata) return;
 
     if (type == PixelType::WS2811) {
-        uart_buffer = pixdata;
-        uart_buffer_tail = pixdata + szBuffer;
-        SET_PERI_REG_MASK(UART_INT_ENA(1), UART_TXFIFO_EMPTY_INT_ENA);
+        // Copy or group the pixels to the idle buffer
+        switch (mode) {
+            case GroupMode::grouped:
+                for (size_t led=0; led < szBuffer/3; led++) {
+                    asyncdata[3*led+0] = pixdata[3*(led/interval)+0];
+                    asyncdata[3*led+1] = pixdata[3*(led/interval)+1];
+                    asyncdata[3*led+2] = pixdata[3*(led/interval)+2];
+                }
+                break;
 
+            case GroupMode::zigzag:
+                for (size_t led=0; led < szBuffer/3; led++) {
+                    if (led/interval%2) { // Odd "zig"
+                        int group = interval * (led / interval);
+                        int this_led = group + interval - (led % interval) - 1;
+                        asyncdata[3*led+0] = pixdata[3*this_led+0];
+                        asyncdata[3*led+1] = pixdata[3*this_led+1];
+                        asyncdata[3*led+2] = pixdata[3*this_led+2];
+                    } else { // Evem "zag"
+                        asyncdata[3*led+0] = pixdata[3*led+0];
+                        asyncdata[3*led+1] = pixdata[3*led+1];
+                        asyncdata[3*led+2] = pixdata[3*led+2];
+                    }
+                }
+                break;
+
+            case GroupMode::disabled:
+                memcpy(asyncdata, pixdata, szBuffer);
+                break;
+
+            default:
+                memcpy(asyncdata, pixdata, szBuffer);
+                break;
+        }
+
+        uart_buffer = asyncdata;
+        uart_buffer_tail = asyncdata + szBuffer;
+
+        SET_PERI_REG_MASK(UART_INT_ENA(1), UART_TXFIFO_EMPTY_INT_ENA);
         startTime = micros();
 
-        // Copy the pixels to the idle buffer and swap them
-        memcpy(asyncdata, pixdata, szBuffer);
-        std::swap(asyncdata, pixdata);
     } else if (type == PixelType::GECE) {
         uint32_t packet = 0;
         uint32_t pTime = 0;
@@ -301,5 +333,6 @@ void ICACHE_RAM_ATTR PixelDriver::show() {
 }
 
 uint8_t* PixelDriver::getData() {
-    return pixdata;
+    return asyncdata;	// data post grouping or zigzaging
+//    return pixdata;
 }

--- a/PixelDriver.h
+++ b/PixelDriver.h
@@ -86,6 +86,13 @@ enum class PixelColor : uint8_t {
     BGR
 };
 
+/* Group Mode */
+enum class GroupMode : uint8_t {
+    disabled,
+    grouped,
+    zigzag
+};
+
 class PixelDriver {
  public:
     int begin();
@@ -102,14 +109,22 @@ class PixelDriver {
         pixdata[address] = value;
     }
 
+    /* Set output mode */
+    inline void setGroupMode(GroupMode _mode, uint16_t _interval) {
+        this->mode = _mode;
+        this->interval = _interval;
+    }
+
     /* Drop the update if our refresh rate is too high */
     inline bool canRefresh() {
         return (micros() - startTime) >= refreshTime;
     }
 
  private:
-    PixelType  type;            // Pixel type
-    PixelColor color;           // Color Order
+    PixelType   type;           // Pixel type
+    PixelColor  color;          // Color Order
+    GroupMode   mode;           // Output modifying mode - normal, grouped, zigzag
+    uint16_t    interval;       // Output modifying interval (in LEDs, not channels)
     uint8_t     pin;            // Pin for bit-banging
     uint8_t     *pixdata;       // Pixel buffer
     uint8_t     *asyncdata;     // Async buffer

--- a/html/index.html
+++ b/html/index.html
@@ -151,8 +151,18 @@
           <div id="o_pixel" class="odiv hidden">
             <legend class="esps-legend">Pixel Configuration</legend>
             <div class="form-group">
-              <label class="control-label col-sm-2" for="p_count">Pixel Count</label>
+              <label class="control-label col-sm-2" for="p_count">Physical Pixels</label>
               <div class="col-sm-10"><input type="text" class="form-control" id="p_count" name="p_count" placeholder="Enter number of pixels" onchange="refreshPixel()"></div>
+            </div>
+            <div class="form-group">
+              <label class="control-label col-sm-2" for="p_groupMode">Output Grouping</label>
+              <div class="col-sm-10">
+                <select class="form-control" id="p_groupMode" name="p_groupMode"></select>
+              </div>
+            </div>
+            <div class="form-group">
+              <label class="control-label col-sm-2" for="p_groupsize">Group Size</label>
+              <div class="col-sm-10"><input type="text" class="form-control" id="p_groupsize" name="p_groupsize" placeholder="Group size of pixels" onchange="refreshPixel()"></div>
             </div>
             <div class="form-group">
               <label class="control-label col-sm-2" for="p_type">Pixel Type</label>

--- a/html/index.html
+++ b/html/index.html
@@ -154,28 +154,27 @@
               <label class="control-label col-sm-2" for="p_count">Physical Pixels</label>
               <div class="col-sm-10"><input type="text" class="form-control" id="p_count" name="p_count" placeholder="Enter number of pixels" onchange="refreshPixel()"></div>
             </div>
-            <div class="form-group">
-              <label class="control-label col-sm-2" for="p_groupMode">Output Grouping</label>
-              <div class="col-sm-10">
-                <select class="form-control" id="p_groupMode" name="p_groupMode"></select>
-              </div>
-            </div>
-            <div class="form-group">
-              <label class="control-label col-sm-2" for="p_groupsize">Group Size</label>
-              <div class="col-sm-10"><input type="text" class="form-control" id="p_groupsize" name="p_groupsize" placeholder="Group size of pixels" onchange="refreshPixel()"></div>
-            </div>
+
             <div class="form-group">
               <label class="control-label col-sm-2" for="p_type">Pixel Type</label>
-              <div class="col-sm-10">
+              <div class="col-sm-3">
                 <select class="form-control" id="p_type" name="p_type" onclick="refreshPixel()"></select>
               </div>
-            </div>
-            <div class="form-group">
               <label class="control-label col-sm-2" for="p_color">Color Order</label>
-              <div class="col-sm-10">
+              <div class="col-sm-3">
                 <select class="form-control" id="p_color" name="p_color"></select>
               </div>
             </div>
+
+            <div class="form-group" id="o_grouping">
+              <label class="control-label col-sm-2" for="p_groupMode">Output Grouping</label>
+              <div class="col-sm-3">
+                <select class="form-control" id="p_groupMode" name="p_groupMode"></select>
+              </div>
+              <label class="control-label col-sm-2" for="p_groupSize">Group Size</label>
+              <div class="col-sm-3"><input type="text" class="form-control" id="p_groupSize" name="p_groupSize" placeholder="Group size of pixels" onchange="refreshPixel()"></div>
+            </div>
+
             <div class="form-group">
               <div class="col-sm-offset-2 col-sm-10">
                 <div class="checkbox"><label><input type="checkbox" id="p_gamma" name="p_gamma"> Gamma Correction</label></div>

--- a/html/script.js
+++ b/html/script.js
@@ -527,8 +527,10 @@ function getConfig(data) {
         mode = 'pixel';
         $('#o_pixel').removeClass('hidden');
         $('#p_count').val(config.e131.channel_count / 3);
+        $('#p_groupsize').val(config.pixel.groupSize);
         $('#p_type').val(config.pixel.type);
         $('#p_color').val(config.pixel.color);
+        $('#p_groupMode').val(config.pixel.groupMode);
         $('#p_gamma').prop('checked', config.pixel.gamma);
         $('#p_gammaVal').val(config.pixel.gammaVal);
         $('#p_briteVal').val(config.pixel.briteVal);
@@ -723,6 +725,8 @@ function submitConfig() {
             'pixel': {
                 'type': parseInt($('#p_type').val()),
                 'color': parseInt($('#p_color').val()),
+                'groupSize': parseInt($('#p_groupsize').val()),
+                'groupMode': parseInt($('#p_groupMode').val()),
                 'gamma': $('#p_gamma').prop('checked'),
                 'gammaVal': parseFloat($('#p_gammaVal').val()),
                 'briteVal': parseFloat($('#p_briteVal').val())

--- a/html/script.js
+++ b/html/script.js
@@ -157,12 +157,23 @@ $(function() {
        }
     });
 
+    // Group type toggles
+    $('#p_groupMode').change(function() {
+        if ($('select[name=p_groupMode]').val() == '0')
+            $('#p_groupSize').prop('disabled', true);
+        else
+            $('#p_groupSize').prop('disabled', false);
+    });
+
     // Pixel type toggles
     $('#p_type').change(function() {
-        if ($('select[name_type]').val() == '1')
+        if ($('select[name=p_type]').val() == '1') {
             $('#p_color').prop('disabled', true);
-        else
+            $('#o_grouping').addClass('hidden');
+        } else {
             $('#p_color').prop('disabled', false);
+            $('#o_grouping').removeClass('hidden');
+        }
     });
 
     // Serial protocol toggles
@@ -527,10 +538,10 @@ function getConfig(data) {
         mode = 'pixel';
         $('#o_pixel').removeClass('hidden');
         $('#p_count').val(config.e131.channel_count / 3);
-        $('#p_groupsize').val(config.pixel.groupSize);
         $('#p_type').val(config.pixel.type);
         $('#p_color').val(config.pixel.color);
         $('#p_groupMode').val(config.pixel.groupMode);
+        $('#p_groupSize').val(config.pixel.groupSize);
         $('#p_gamma').prop('checked', config.pixel.gamma);
         $('#p_gammaVal').val(config.pixel.gammaVal);
         $('#p_briteVal').val(config.pixel.briteVal);
@@ -725,8 +736,8 @@ function submitConfig() {
             'pixel': {
                 'type': parseInt($('#p_type').val()),
                 'color': parseInt($('#p_color').val()),
-                'groupSize': parseInt($('#p_groupsize').val()),
                 'groupMode': parseInt($('#p_groupMode').val()),
+                'groupSize': parseInt($('#p_groupSize').val()),
                 'gamma': $('#p_gamma').prop('checked'),
                 'gammaVal': parseFloat($('#p_gammaVal').val()),
                 'briteVal': parseFloat($('#p_briteVal').val())

--- a/wshandler.h
+++ b/wshandler.h
@@ -117,6 +117,12 @@ void procE(uint8_t *data, AsyncWebSocketClient *client) {
             p_color["GBR"] = static_cast<uint8_t>(PixelColor::GBR);
             p_color["BGR"] = static_cast<uint8_t>(PixelColor::BGR);
 
+            // Pixel Colors
+            JsonObject &p_groupMode = json.createNestedObject("p_groupMode");
+            p_groupMode["Disabled"]  = static_cast<uint8_t>(GroupMode::disabled);
+            p_groupMode["Grouped"] = static_cast<uint8_t>(GroupMode::grouped);
+            p_groupMode["Zig-Zag"] = static_cast<uint8_t>(GroupMode::zigzag);
+
 #elif defined (ESPS_MODE_SERIAL)
             // Serial Protocols
             JsonObject &s_proto = json.createNestedObject("s_proto");


### PR DESCRIPTION
Grouping and zig-zag support for ws2811 strips
- Output Grouping can be disabled, grouped or zig-zag
- Group size specifies the size of groups or zig-zag period (in LEDs, not dmx channels)
Its implemented in the pixeldriver so both e.131 and effect data use the grouping config