### PR TITLE
Add ZCPP support to ESPixelStick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .build
 *.gz
 package-lock.json
+*.ino.generic.bin

--- a/ESPAsyncZCPP.cpp
+++ b/ESPAsyncZCPP.cpp
@@ -1,0 +1,194 @@
+/*
+* ESPAsyncZCPP.cpp
+*
+* Project: ESPAsyncZCPP - Asynchronous ZCPP library for Arduino ESP8266 and ESP32
+* Copyright (c) 2019 Keith Westley
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*/
+
+#include "ESPAsyncZCPP.h"
+#include <string.h>
+
+// Constructor
+ESPAsyncZCPP::ESPAsyncZCPP(uint8_t buffers) {
+    pbuff = RingBuf_new(sizeof(ZCPP_packet_t), buffers);
+	suspend = false;
+	
+    stats.num_packets = 0;
+    stats.packet_errors = 0;
+}
+
+/////////////////////////////////////////////////////////
+//
+// Public begin() members
+//
+/////////////////////////////////////////////////////////
+
+bool ESPAsyncZCPP::begin(IPAddress ourIP) {
+
+	suspend = false;
+	return initUDP(ourIP);
+}
+
+/////////////////////////////////////////////////////////
+//
+// Private init() members
+//
+/////////////////////////////////////////////////////////
+
+bool ESPAsyncZCPP::initUDP(IPAddress ourIP) {
+    bool success = false;
+    delay(100);
+
+    IPAddress address = IPAddress(224, 0, 30, 5);
+    if (udp.listenMulticast(address, ZCPP_PORT)) {
+        udp.onPacket(std::bind(&ESPAsyncZCPP::parsePacket, this,
+                std::placeholders::_1));
+
+        success = true;
+    }
+	
+	ip_addr_t ifaddr;
+    ip_addr_t multicast_addr;
+	ifaddr.addr = static_cast<uint32_t>(ourIP);
+	multicast_addr.addr = static_cast<uint32_t>(IPAddress(224, 0, 31, ourIP[4]));
+	igmp_joingroup(&ifaddr, &multicast_addr);
+
+    return success;
+}
+
+/////////////////////////////////////////////////////////
+//
+// Packet parsing - Private
+//
+/////////////////////////////////////////////////////////
+
+void ESPAsyncZCPP::parsePacket(AsyncUDPPacket _packet) {
+    ZCPP_error_t error = ERROR_ZCPP_NONE;
+
+    sbuff = reinterpret_cast<ZCPP_packet_t *>(_packet.data());
+    if (memcmp(sbuff->Discovery.Header.token, ZCPP_token, sizeof(sbuff->Discovery.Header.token)))
+        error = ERROR_ZCPP_ID;
+
+	if (!error && sbuff->Discovery.Header.type != ZCPP_TYPE_DISCOVERY &&
+		sbuff->Discovery.Header.type != ZCPP_TYPE_CONFIG &&
+		sbuff->Discovery.Header.type != ZCPP_TYPE_SYNC &&
+		sbuff->Discovery.Header.type != ZCPP_TYPE_DATA)
+	{
+		error = ERROR_ZCPP_IGNORE;
+	}
+
+	if (sbuff->Discovery.Header.protocolVersion > ZCPP_CURRENT_PROTOCOL_VERSION)
+	{
+		if (sbuff->Discovery.Header.type == 0x00)
+		{
+			error = ERROR_ZCPP_NONE;
+		}
+		else if (!error)
+		{
+			error = ERROR_ZCPP_PROTOCOL_VERSION;
+		}
+	}
+
+    if (!error && (!suspend || sbuff->Discovery.Header.type == ZCPP_TYPE_DISCOVERY)) {
+		
+		if (sbuff->Discovery.Header.type == ZCPP_TYPE_DISCOVERY)
+		{
+			suspend = true;
+		}
+		
+        pbuff->add(pbuff, sbuff);
+        stats.num_packets++;
+        stats.last_clientIP = _packet.remoteIP();
+        stats.last_clientPort = _packet.remotePort();
+        stats.last_seen = millis();
+    } else if (error == ERROR_ZCPP_IGNORE || suspend) {
+        // Do nothing
+    } else {
+        if (Serial)
+            dumpError(error);
+        stats.packet_errors++;
+    }
+}
+
+/////////////////////////////////////////////////////////
+//
+// Debugging functions - Public
+//
+/////////////////////////////////////////////////////////
+
+void ESPAsyncZCPP::dumpError(ZCPP_error_t error) {
+    switch (error) {
+        case ERROR_ZCPP_ID:
+            Serial.print(F("INVALID PACKET ID: "));
+            for (uint i = 0; i < sizeof(ZCPP_token); i++)
+                Serial.print(sbuff->Discovery.Header.token[i], HEX);
+            Serial.println("");
+            break;
+        case ERROR_ZCPP_PROTOCOL_VERSION:
+            Serial.print(F("INVALID PROTOCOL VERSION: 0x"));
+            Serial.println(sbuff->Discovery.Header.protocolVersion, HEX);
+            break;
+        case ERROR_ZCPP_NONE:
+            break;
+        case ERROR_ZCPP_IGNORE:
+            break;
+    }
+}
+
+void ESPAsyncZCPP::sendDiscoveryResponse(ZCPP_packet_t* packet, const char* firmwareVersion, const uint8_t* mac, const char* controllerName, int pixelPorts, int serialPorts, uint32_t maxPixelPortChannels, uint32_t maxSerialPortChannels, uint32_t maximumChannels, uint32_t ipAddress, uint32_t ipMask)
+{
+	memset(packet, 0x00, sizeof(ZCPP_packet_t));
+	memcpy(packet->DiscoveryResponse.Header.token, ZCPP_token, sizeof(ZCPP_token));
+	packet->DiscoveryResponse.Header.type = ZCPP_TYPE_DISCOVERY_RESPONSE;
+	packet->DiscoveryResponse.Header.protocolVersion = ZCPP_CURRENT_PROTOCOL_VERSION;
+	packet->DiscoveryResponse.minProtocolVersion = ZCPP_CURRENT_PROTOCOL_VERSION;
+	packet->DiscoveryResponse.maxProtocolVersion = ZCPP_CURRENT_PROTOCOL_VERSION;
+	packet->DiscoveryResponse.vendor = ntohs(ZCPP_VENDOR_ESPIXELSTICK);
+	packet->DiscoveryResponse.model = ntohs(0);
+	strncpy(packet->DiscoveryResponse.firmwareVersion, firmwareVersion, std::min((int)strlen(firmwareVersion), (int)sizeof(packet->DiscoveryResponse.firmwareVersion)));
+	memcpy(packet->DiscoveryResponse.macAddress, mac, sizeof(packet->DiscoveryResponse.macAddress));
+	packet->DiscoveryResponse.ipv4Address = ipAddress;
+	packet->DiscoveryResponse.ipv4Mask = ipMask;	
+	strncpy(packet->DiscoveryResponse.userControllerName, controllerName, std::min((int)strlen(controllerName), (int)sizeof(packet->DiscoveryResponse.userControllerName)));
+	packet->DiscoveryResponse.pixelPorts = pixelPorts;
+	packet->DiscoveryResponse.rsPorts = serialPorts;
+	packet->DiscoveryResponse.channelsPerPixelPort = ntohs(maxPixelPortChannels); 
+	packet->DiscoveryResponse.channelsPerRSPort = ntohs(maxSerialPortChannels);
+	packet->DiscoveryResponse.maxTotalChannels = ntohl(maximumChannels);
+	uint32_t protocolsSupported = 0;
+	if (pixelPorts >0)
+	{
+		protocolsSupported |= ZCPP_DISCOVERY_PROTOCOL_WS2811;
+		protocolsSupported |= ZCPP_DISCOVERY_PROTOCOL_GECE;
+	}
+	if (serialPorts > 0)
+	{
+		protocolsSupported |= ZCPP_DISCOVERY_PROTOCOL_DMX;
+		protocolsSupported |= ZCPP_DISCOVERY_PROTOCOL_RENARD;
+	}
+	packet->DiscoveryResponse.protocolsSupported = ntohl(protocolsSupported);
+	packet->DiscoveryResponse.flags = ZCPP_DISCOVERY_FLAG_SEND_DATA_AS_MULTICAST;
+
+	if (udp.writeTo(packet->raw, sizeof(packet->DiscoveryResponse), stats.last_clientIP, stats.last_clientPort) != sizeof(packet->DiscoveryResponse))
+	{
+		Serial.println("Write of discovery response failed");
+	}
+	else
+	{
+		Serial.print("Discovery response wrote ");
+		Serial.print(sizeof(packet->DiscoveryResponse));
+		Serial.println(" bytes.");
+	}
+	suspend = false;
+}

--- a/ESPAsyncZCPP.h
+++ b/ESPAsyncZCPP.h
@@ -1,0 +1,91 @@
+/*
+* ESPAsyncZCPP.h
+*
+* Project: ESPAsyncZCPP - Asynchronous ZCPP library for Arduino ESP8266 and ESP32
+* Copyright (c) 2019 Keith Westley
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*/
+
+#ifndef ESPASYNCZCPP_H_
+#define ESPASYNCZCPP_H_
+
+#ifdef ESP32
+#include <WiFi.h>
+#include <AsyncUDP.h>
+#elif defined (ESP8266)
+#include <ESPAsyncUDP.h>
+#include <ESP8266WiFi.h>
+#include <ESP8266WiFiMulti.h>
+#else
+#error Platform not supported
+#endif
+
+#include <lwip/ip_addr.h>
+#include <lwip/igmp.h>
+#include <Arduino.h>
+#include "RingBuf.h"
+
+#if LWIP_VERSION_MAJOR == 1
+typedef struct ip_addr ip4_addr_t;
+#endif
+
+#include "ZCPP.h"
+
+// Error Types
+typedef enum {
+    ERROR_ZCPP_NONE,
+    ERROR_ZCPP_IGNORE,
+    ERROR_ZCPP_ID,
+    ERROR_ZCPP_PROTOCOL_VERSION,
+} ZCPP_error_t;
+
+// Status structure
+typedef struct {
+    uint32_t    num_packets;
+    uint32_t    packet_errors;
+    IPAddress   last_clientIP;
+    uint16_t    last_clientPort;
+    unsigned long    last_seen;
+} ZCPP_stats_t;
+
+class ESPAsyncZCPP {
+ private:
+
+	ZCPP_packet_t   *sbuff;       // Pointer to scratch packet buffer
+    AsyncUDP        udp;          // UDP
+    RingBuf         *pbuff;       // Ring Buffer of universe packet buffers
+	bool            suspend;      // suspends all ZCPP processing until discovery is responded to
+	
+    // Internal Initializers
+    bool initUDP(IPAddress ourIP);
+
+    // Packet parser callback
+    void parsePacket(AsyncUDPPacket _packet);
+
+ public:
+    ZCPP_stats_t  stats;    // Statistics tracker
+
+    ESPAsyncZCPP(uint8_t buffers = 1);
+
+    // Generic UDP listener, no physical or IP configuration
+    bool begin(IPAddress ourIP);
+
+    // Ring buffer access
+    inline bool isEmpty() { return pbuff->isEmpty(pbuff); }
+    inline void *pull(ZCPP_packet_t *packet) { return pbuff->pull(pbuff, packet); }
+	void sendDiscoveryResponse(ZCPP_packet_t* packet, const char* firmwareVersion, const uint8_t* mac, const char* controllerName, int pixelPorts, int serialPorts, uint32_t maxPixelPortChannels, uint32_t maxSerialPortChannels, uint32_t maximumChannels, uint32_t ipAddress, uint32_t ipMask);
+
+    // Diag functions
+    void dumpError(ZCPP_error_t error);
+};
+#endif  // ESPASYNCZCPP_H_

--- a/ESPAsyncZCPP.h
+++ b/ESPAsyncZCPP.h
@@ -83,7 +83,8 @@ class ESPAsyncZCPP {
     // Ring buffer access
     inline bool isEmpty() { return pbuff->isEmpty(pbuff); }
     inline void *pull(ZCPP_packet_t *packet) { return pbuff->pull(pbuff, packet); }
-	void sendDiscoveryResponse(ZCPP_packet_t* packet, const char* firmwareVersion, const uint8_t* mac, const char* controllerName, int pixelPorts, int serialPorts, uint32_t maxPixelPortChannels, uint32_t maxSerialPortChannels, uint32_t maximumChannels, uint32_t ipAddress, uint32_t ipMask);
+	  void sendDiscoveryResponse(ZCPP_packet_t* packet, const char* firmwareVersion, const uint8_t* mac, const char* controllerName, int pixelPorts, int serialPorts, uint32_t maxPixelPortChannels, uint32_t maxSerialPortChannels, uint32_t maximumChannels, uint32_t ipAddress, uint32_t ipMask);
+    void sendConfigResponse(ZCPP_packet_t* packet);
 
     // Diag functions
     void dumpError(ZCPP_error_t error);

--- a/ESPixelStick.h
+++ b/ESPixelStick.h
@@ -80,7 +80,8 @@ enum class DataSource : uint8_t {
     E131,
     MQTT,
     WEB,
-    IDLEWEB
+    IDLEWEB,
+    ZCPP
 };
 
 // Configuration structure

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -1413,7 +1413,7 @@ void loop() {
                     break;
                   case ZCPP_TYPE_DATA: // data
                       uint8_t seq = zcppPacket.Data.sequenceNumber;
-                      uint32_t offset = htonl(zcppPacket.Data.frameAddress);
+                      uint16_t offset = htons(zcppPacket.Data.frameAddress);
                       bool frameLast = zcppPacket.Data.flags & ZCPP_DATA_FLAG_LAST;
                       uint16_t len = htons(zcppPacket.Data.packetDataLength);
                       bool sync = (zcppPacket.Data.flags & ZCPP_DATA_FLAG_SYNC_WILL_BE_SENT) != 0;

--- a/ZCPP.h
+++ b/ZCPP.h
@@ -96,9 +96,9 @@
 #define ZCPP_COLOUR_ORDER_BRG 0x04
 #define ZCPP_COLOUR_ORDER_BGR 0x05
 
-#define ZCPP_CONFIG_FLAG_QUERY_CONFIGURATION_RESPONSE_REQUIRED 0x10 
-#define ZCPP_CONFIG_FLAG_FIRST 0x40 
-#define ZCPP_CONFIG_FLAG_LAST 0x80 
+#define ZCPP_CONFIG_FLAG_QUERY_CONFIGURATION_RESPONSE_REQUIRED 0x10
+#define ZCPP_CONFIG_FLAG_FIRST 0x40
+#define ZCPP_CONFIG_FLAG_LAST 0x80
 
 #define ZCPP_CONFIG_MAX_PORT_PER_PACKET 100
 
@@ -156,7 +156,7 @@ const uint8_t ZCPP_token[4] = {'Z', 'C', 'P', 'P'};
 #endif
 
 // Common header across all packet types - 6 bytes
-typedef 
+typedef
 #ifndef _MSC_VER
 __attribute__((packed))
 #endif
@@ -167,7 +167,7 @@ struct {
 } ZCPP_Header;
 
 // Discovery Request - 8 bytes
-typedef 
+typedef
 #ifndef _MSC_VER
 __attribute__((packed))
 #endif
@@ -178,7 +178,7 @@ struct {
 } ZCPP_Discovery;
 
 // Discovery Response - 86 bytes
-typedef 
+typedef
 #ifndef _MSC_VER
 __attribute__((packed))
 #endif
@@ -206,7 +206,7 @@ struct {
 } ZCPP_DiscoveryResponse;
 
 // Describes the configuration of a port or virtual string - 14 bytes
-typedef 
+typedef
 #ifndef _MSC_VER
 __attribute__((packed))
 #endif
@@ -224,7 +224,7 @@ struct {
 } ZCPP_PortConfig;
 
 // Configuration - 42 - 1442 bytes
-typedef 
+typedef
 #ifndef _MSC_VER
 __attribute__((packed))
 #endif
@@ -234,15 +234,11 @@ struct {
 	char userControllerName[32];	// Up to 32 characters of user controller name
 	uint8_t flags;					// Configuration flags
 	uint8_t ports;					// Number of ports being configured
-#ifdef _MSC_VER
     ZCPP_PortConfig PortConfig[1];		// Up to 100 of them
-#else
-    ZCPP_PortConfig PortConfig[];		// Up to 100 of them
-#endif
 } ZCPP_Configuration;
 
 // Query Configuration Response 42 - 1442 bytes
-typedef 
+typedef
 #ifndef _MSC_VER
 __attribute__((packed))
 #endif
@@ -252,15 +248,11 @@ struct {
 	char userControllerName[32];	// Up to 32 characters of user controller name
 	uint8_t flags;					// Configuration result flags
 	uint8_t ports;					// Number of ports configured
-#ifdef _MSC_VER
     ZCPP_PortConfig PortConfig[1];		// Up to 100 of them
-#else
-    ZCPP_PortConfig PortConfig[];		// Up to 100 of them
-#endif
 } ZCPP_QueryConfigurationResponse;
 
 // QueryConfiguration - 6 bytes
-typedef 
+typedef
 #ifndef _MSC_VER
 __attribute__((packed))
 #endif
@@ -269,7 +261,7 @@ struct {
 } ZCPP_QueryConfiguration;
 
 // Extra port data - 3 - 1490 bytes
-typedef 
+typedef
 #ifndef _MSC_VER
 __attribute__((packed))
 #endif
@@ -277,15 +269,11 @@ struct {
 	uint8_t port;					// zero based port that is being configured
 	uint8_t string;					// smart remote and virtual string number within port
 	uint8_t descriptionLength;		// length of the description which must fit entirely within this ethernet frame
-#ifdef _MSC_VER
     char description[1];				// the port description
-#else
-    char description[];				// the port description
-#endif
 } ZCPP_PortExtraData;
 
 // Extra port configuration data - 10 - 1500 bytes
-typedef 
+typedef
 #ifndef _MSC_VER
 __attribute__((packed))
 #endif
@@ -294,15 +282,11 @@ struct {
 	uint16_t sequenceNumber;		// sequence number unique each time the configuration changes
 	uint8_t flags;					// Configuration flags
 	uint8_t ports;					// Number of ports being configured
-#ifdef _MSC_VER
     ZCPP_PortExtraData PortExtraData[1];
-#else
-    ZCPP_PortExtraData PortExtraData[];
-#endif
 } ZCPP_ExtraData;
 
 // Sync - 7 bytes
-typedef 
+typedef
 #ifndef _MSC_VER
 __attribute__((packed))
 #endif
@@ -312,23 +296,19 @@ struct {
 } ZCPP_Sync;
 
 // Data - 14 - 1500 bytes
-typedef 
+typedef
 #ifndef _MSC_VER
-__attribute__((packed)) 
+__attribute__((packed))
 #endif
 struct {
 	ZCPP_Header Header;
 	uint8_t sequenceNumber;			// sequence number matching of the data frame. If multiple packets are needed all packets in the
-									// same frame will have the same sequence number. Frame numbers start at zero and increment and 
+									// same frame will have the same sequence number. Frame numbers start at zero and increment and
 									// then go back to zero
 	uint8_t flags;					// data packet flags
     uint32_t frameAddress;			// where in the zero based data address space the data in this packet belongs
     uint16_t packetDataLength;		// how many data bytes are in this packet
-#ifdef _MSC_VER
     uint8_t data[1];
-#else
-    uint8_t data[];
-#endif
 } ZCPP_Data;
 
 typedef
@@ -339,10 +319,10 @@ union {
 	// sent discovery
 	ZCPP_Discovery Discovery;
 		// Must lead to a DiscoveryResponse
-	
+
 	// discovery response
 	ZCPP_DiscoveryResponse DiscoveryResponse;
-	
+
 	// configuration
 	ZCPP_Configuration Configuration;
 		// May optionally lead to a QueryConfigurationResponse

--- a/ZCPP.h
+++ b/ZCPP.h
@@ -214,9 +214,9 @@ struct {
 	uint8_t port;					// zero based port that is being configured
 	uint8_t string;					// smart remote and virtual string number within port
     uint16_t startChannel;			// zero based start channel within the ZCPP data space
-    uint8_t protocol;				// port protocol
 	uint16_t channels;				// number of channels to send out this port
-	uint8_t grouping;				// pixel grouping on this port. If 2 then channels 123456789 becomes 123123456456789789
+    uint8_t protocol;				// port protocol
+    uint8_t grouping;				// pixel grouping on this port. If 2 then channels 123456789 becomes 123123456456789789
 	uint8_t directionColourOrder;   // should data be reversed and what is the pixel colour order
 	uint8_t nullPixels;				// number of null pixels at the start of this string
 	uint8_t brightness;				// 0-100 brightness
@@ -260,7 +260,7 @@ struct {
 	ZCPP_Header Header;
 } ZCPP_QueryConfiguration;
 
-// Extra port data - 3 - 1490 bytes
+// Extra port data - 3 - 1458 bytes
 typedef
 #ifndef _MSC_VER
 __attribute__((packed))
@@ -272,7 +272,7 @@ struct {
     char description[1];				// the port description
 } ZCPP_PortExtraData;
 
-// Extra port configuration data - 10 - 1500 bytes
+// Extra port configuration data - 10 - 1458 bytes
 typedef
 #ifndef _MSC_VER
 __attribute__((packed))
@@ -295,7 +295,7 @@ struct {
 	uint8_t sequenceNumber;			// sequence number matching the data frame sequence number this sync packet is for
 } ZCPP_Sync;
 
-// Data - 14 - 1500 bytes
+// Data - 14 - 1458 bytes
 typedef
 #ifndef _MSC_VER
 __attribute__((packed))
@@ -344,7 +344,7 @@ union {
 	// sync
 	ZCPP_Sync Sync;
 
-    uint8_t raw[1500];
+    uint8_t raw[1458];
 } ZCPP_packet_t;
 
 #ifdef _MSC_VER

--- a/ZCPP.h
+++ b/ZCPP.h
@@ -41,22 +41,22 @@
 #define ZCPP_VENDOR_FPP 0x0001
 #define ZCPP_VENDOR_ESPIXELSTICK 0x0002
 
-#define ZCPP_DISCOVERY_PROTOCOL_WS2811 0x00000001
-#define ZCPP_DISCOVERY_PROTOCOL_GECE 0x000000002
-#define ZCPP_DISCOVERY_PROTOCOL_DMX 0x000000004
-#define ZCPP_DISCOVERY_PROTOCOL_LX1203 0x00000008
+#define ZCPP_DISCOVERY_PROTOCOL_WS2811  0x00000001
+#define ZCPP_DISCOVERY_PROTOCOL_GECE    0x00000002
+#define ZCPP_DISCOVERY_PROTOCOL_DMX     0x00000004
+#define ZCPP_DISCOVERY_PROTOCOL_LX1203  0x00000008
 #define ZCPP_DISCOVERY_PROTOCOL_TLS3001 0x00000010
 #define ZCPP_DISCOVERY_PROTOCOL_LPD6803 0x00000020
-#define ZCPP_DISCOVERY_PROTOCOL_WS2801 0x00000040
+#define ZCPP_DISCOVERY_PROTOCOL_WS2801  0x00000040
 #define ZCPP_DISCOVERY_PROTOCOL_SM16716 0x00000080
 #define ZCPP_DISCOVERY_PROTOCOL_MB16020 0x00000100
-#define ZCPP_DISCOVERY_PROTOCOL_MY9231 0x00000200
-#define ZCPP_DISCOVERY_PROTOCOL_APA102 0x00000400
-#define ZCPP_DISCOVERY_PROTOCOL_MY9221 0x00000800
-#define ZCPP_DISCOVERY_PROTOCOL_SK6812 0x00001000
+#define ZCPP_DISCOVERY_PROTOCOL_MY9231  0x00000200
+#define ZCPP_DISCOVERY_PROTOCOL_APA102  0x00000400
+#define ZCPP_DISCOVERY_PROTOCOL_MY9221  0x00000800
+#define ZCPP_DISCOVERY_PROTOCOL_SK6812  0x00001000
 #define ZCPP_DISCOVERY_PROTOCOL_UCS1903 0x00002000
-#define ZCPP_DISCOVERY_PROTOCOL_TM18XX 0x00004000
-#define ZCPP_DISCOVERY_PROTOCOL_RENARD 0x00008000
+#define ZCPP_DISCOVERY_PROTOCOL_TM18XX  0x00004000
+#define ZCPP_DISCOVERY_PROTOCOL_RENARD  0x00008000
 
 #define ZCPP_PROTOCOL_WS2811 0x00
 #define ZCPP_PROTOCOL_GECE 0x01
@@ -78,10 +78,10 @@
 // when ZCPP_DISCOVERY_FLAG_SEND_DATA_AS_MULTICAST is set the controllers IP is slightly ignored
 // if controller IP is 10.10.10.10 then the data will be multicast to 224.0.31.10 ... ie the last octet is added
 // to ZCPP_MULTICAST_DATA_ADDRESS
-#define ZCPP_DISCOVERY_FLAG_SEND_DATA_AS_MULTICAST 0x02
-#define ZCPP_DISCOVERY_FLAG_CONFIGURATION_LOCKED 0x04
-#define ZCPP_DISCOVERY_FLAG_SUPPORTS_VIRTUAL_STRINGS 0x08
-#define ZCPP_DISCOVERY_FLAG_SUPPORTS_SMART_REMOTES 0x10
+#define ZCPP_DISCOVERY_FLAG_SEND_DATA_AS_MULTICAST 0x0002
+#define ZCPP_DISCOVERY_FLAG_CONFIGURATION_LOCKED 0x0004
+#define ZCPP_DISCOVERY_FLAG_SUPPORTS_VIRTUAL_STRINGS 0x0008
+#define ZCPP_DISCOVERY_FLAG_SUPPORTS_SMART_REMOTES 0x0010
 
 #define ZCPP_SMART_REMOTE_MASK 0xC0
 #define ZCPP_STRING_NUMBER_MASK 0x3F
@@ -100,7 +100,7 @@
 #define ZCPP_CONFIG_FLAG_FIRST 0x40
 #define ZCPP_CONFIG_FLAG_LAST 0x80
 
-#define ZCPP_CONFIG_MAX_PORT_PER_PACKET 100
+#define ZCPP_CONFIG_MAX_PORT_PER_PACKET 115
 
 #define ZCPP_CONFIGURATION_QUERY_ERRORS 0x01
 
@@ -109,43 +109,43 @@
 #define ZCPP_DATA_FLAG_LAST 0x80
 
 inline uint8_t ZCPP_GetSmartRemote(uint8_t string) {
-	return (string & ZCPP_SMART_REMOTE_MASK) >> 6;
+  return (string & ZCPP_SMART_REMOTE_MASK) >> 6;
 }
 
 inline uint8_t ZCPP_GetStringNumber(uint8_t string) {
-	return (string & ZCPP_STRING_NUMBER_MASK);
+  return (string & ZCPP_STRING_NUMBER_MASK);
 }
 
 inline bool ZCPP_IsReversed(uint8_t directionColourOrder) {
-	return (directionColourOrder & ZCPP_REVERSE_MASK) != 0;
+  return (directionColourOrder & ZCPP_REVERSE_MASK) != 0;
 }
 
 inline uint8_t ZCPP_GetColourOrder(uint8_t directionColourOrder) {
-	return directionColourOrder & ZCPP_COLOUR_ORDER_MASK;
+  return directionColourOrder & ZCPP_COLOUR_ORDER_MASK;
 }
 
 inline float ZCPP_GetGamma(uint8_t gamma) {
-	return static_cast<float>(gamma) / 10.0;
+  return static_cast<float>(gamma) / 10.0;
 }
 
 inline uint8_t ZCPP_ConvertDiscoveryProtocolToProtocol(uint32_t discoveryProtocol) {
-	uint8_t res = 0x00;
-	discoveryProtocol = discoveryProtocol > 1;
-	while (discoveryProtocol != 0) 	{
-		res++;
-		discoveryProtocol = discoveryProtocol > 1;
-	}
-	return res;
+  uint8_t res = 0x00;
+  discoveryProtocol = discoveryProtocol > 1;
+  while (discoveryProtocol != 0)  {
+    res++;
+    discoveryProtocol = discoveryProtocol > 1;
+  }
+  return res;
 }
 
 inline uint32_t ZCPP_ConvertProtocolToDiscoveryProtocol(uint8_t protocol)
 {
-	uint32_t res = 0x00000001;
-	while (protocol != 0) 	{
-		protocol--;
-		res = res << 1;
-	}
-	return res;
+  uint32_t res = 0x00000001;
+  while (protocol != 0)   {
+    protocol--;
+    res = res << 1;
+  }
+  return res;
 }
 
 const uint8_t ZCPP_token[4] = {'Z', 'C', 'P', 'P'};
@@ -161,9 +161,9 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-	uint8_t token[4]; 			// Always ZCPP
-	uint8_t type;				// packet type
-	uint8_t protocolVersion;	// version of the protocol
+  uint8_t token[4];       // Always ZCPP
+  uint8_t type;       // packet type
+  uint8_t protocolVersion;  // version of the protocol
 } ZCPP_Header;
 
 // Discovery Request - 8 bytes
@@ -172,55 +172,55 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-	ZCPP_Header Header;
-	uint8_t minProtocolVersion; // The minimum version of the protocol the requester supports
-	uint8_t maxProtocolVersion; // The maximum version of the protocol the requester supports
+  ZCPP_Header Header;
+  uint8_t minProtocolVersion; // The minimum version of the protocol the requester supports
+  uint8_t maxProtocolVersion; // The maximum version of the protocol the requester supports
 } ZCPP_Discovery;
 
-// Discovery Response - 86 bytes
+// Discovery Response - 88 bytes
 typedef
 #ifndef _MSC_VER
 __attribute__((packed))
 #endif
 struct {
-	ZCPP_Header Header;
-	uint8_t minProtocolVersion; // The minimum version of the protocol the controller supports
-	uint8_t maxProtocolVersion; // The maximum version of the protocol the controller supports
-	uint16_t vendor;			// The vendor of the controller
-	uint16_t model;				// A vendor specific model code
-	char firmwareVersion[12];	// A string of up to 12 characters which is the firmware version as a string. It does not
-								// need to be null terminated but should be null filled if all 12 characters are not used
-	uint8_t macAddress[6];		// The controllers mac Address
+  ZCPP_Header Header;
+  uint8_t minProtocolVersion; // The minimum version of the protocol the controller supports
+  uint8_t maxProtocolVersion; // The maximum version of the protocol the controller supports
+  uint16_t vendor;      // The vendor of the controller
+  uint16_t model;       // A vendor specific model code
+  char firmwareVersion[12]; // A string of up to 12 characters which is the firmware version as a string. It does not
+                // need to be null terminated but should be null filled if all 12 characters are not used
+  uint8_t macAddress[6];    // The controllers mac Address
     uint8_t filler1[2];
-	uint32_t ipv4Address;		// The controllers IP V4 IP Address
-	uint32_t ipv4Mask;			// The controllers IP V4 Subnet Mask
-	char userControllerName[32];// Up to 32 characters of user controller name
+  uint32_t ipv4Address;   // The controllers IP V4 IP Address
+  uint32_t ipv4Mask;      // The controllers IP V4 Subnet Mask
+  char userControllerName[32];// Up to 32 characters of user controller name
     uint32_t maxTotalChannels;  // Maximum number of channels that the controller will accept. This may not just be the sum
                                 // of all port channels as the controller may have some global limits
-    uint8_t pixelPorts;			// Number of pixel ports supported by the controller
-	uint8_t rsPorts;			// Number of RSxxx ports supported by the controller
-	uint16_t channelsPerPixelPort; // Maximum number of channels each pixel port can accept
-	uint16_t channelsPerRSPort; // Maximum number of channels each RSxxx port can accept
-    uint16_t flags;				// Discovery Flags
+    uint8_t pixelPorts;     // Number of pixel ports supported by the controller
+  uint8_t rsPorts;      // Number of RSxxx ports supported by the controller
+  uint16_t channelsPerPixelPort; // Maximum number of channels each pixel port can accept
+  uint16_t channelsPerRSPort; // Maximum number of channels each RSxxx port can accept
+    uint16_t flags;       // Discovery Flags
     uint32_t protocolsSupported; // Bitmask of all supported protocols
 } ZCPP_DiscoveryResponse;
 
-// Describes the configuration of a port or virtual string - 14 bytes
+// Describes the configuration of a port or virtual string - 12 bytes
 typedef
 #ifndef _MSC_VER
 __attribute__((packed))
 #endif
 struct {
-	uint8_t port;					// zero based port that is being configured
-	uint8_t string;					// smart remote and virtual string number within port
-    uint16_t startChannel;			// zero based start channel within the ZCPP data space
-	uint16_t channels;				// number of channels to send out this port
-    uint8_t protocol;				// port protocol
-    uint8_t grouping;				// pixel grouping on this port. If 2 then channels 123456789 becomes 123123456456789789
-	uint8_t directionColourOrder;   // should data be reversed and what is the pixel colour order
-	uint8_t nullPixels;				// number of null pixels at the start of this string
-	uint8_t brightness;				// 0-100 brightness
-	uint8_t gamma;					// Gamma * 10
+  uint8_t port;         // zero based port that is being configured
+  uint8_t string;         // smart remote and virtual string number within port
+    uint16_t startChannel;      // zero based start channel within the ZCPP data space
+  uint16_t channels;        // number of channels to send out this port
+    uint8_t protocol;       // port protocol
+    uint8_t grouping;       // pixel grouping on this port. If 2 then channels 123456789 becomes 123123456456789789
+  uint8_t directionColourOrder;   // should data be reversed and what is the pixel colour order
+  uint8_t nullPixels;       // number of null pixels at the start of this string
+  uint8_t brightness;       // 0-100 brightness
+  uint8_t gamma;          // Gamma * 10
 } ZCPP_PortConfig;
 
 // Configuration - 42 - 1442 bytes
@@ -229,12 +229,12 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-	ZCPP_Header Header;
-	uint16_t sequenceNumber;		// sequence number unique each time the configuration changes
-	char userControllerName[32];	// Up to 32 characters of user controller name
-	uint8_t flags;					// Configuration flags
-	uint8_t ports;					// Number of ports being configured
-    ZCPP_PortConfig PortConfig[1];		// Up to 100 of them
+  ZCPP_Header Header;
+  uint16_t sequenceNumber;    // sequence number unique each time the configuration changes
+  char userControllerName[32];  // Up to 32 characters of user controller name
+  uint8_t flags;          // Configuration flags
+  uint8_t ports;          // Number of ports being configured
+    ZCPP_PortConfig PortConfig[1];    // Up to 100 of them
 } ZCPP_Configuration;
 
 // Query Configuration Response 42 - 1442 bytes
@@ -243,12 +243,12 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-	ZCPP_Header Header;
-	uint16_t sequenceNumber;		// sequence number unique each time the configuration changes
-	char userControllerName[32];	// Up to 32 characters of user controller name
-	uint8_t flags;					// Configuration result flags
-	uint8_t ports;					// Number of ports configured
-    ZCPP_PortConfig PortConfig[1];		// Up to 100 of them
+  ZCPP_Header Header;
+  uint16_t sequenceNumber;    // sequence number unique each time the configuration changes
+  char userControllerName[32];  // Up to 32 characters of user controller name
+  uint8_t flags;          // Configuration result flags
+  uint8_t ports;          // Number of ports configured
+    ZCPP_PortConfig PortConfig[1];    // Up to 100 of them
 } ZCPP_QueryConfigurationResponse;
 
 // QueryConfiguration - 6 bytes
@@ -257,7 +257,7 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-	ZCPP_Header Header;
+  ZCPP_Header Header;
 } ZCPP_QueryConfiguration;
 
 // Extra port data - 3 - 1458 bytes
@@ -266,10 +266,10 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-	uint8_t port;					// zero based port that is being configured
-	uint8_t string;					// smart remote and virtual string number within port
-	uint8_t descriptionLength;		// length of the description which must fit entirely within this ethernet frame
-    char description[1];				// the port description
+  uint8_t port;         // zero based port that is being configured
+  uint8_t string;         // smart remote and virtual string number within port
+  uint8_t descriptionLength;    // length of the description which must fit entirely within this ethernet frame
+    char description[1];        // the port description
 } ZCPP_PortExtraData;
 
 // Extra port configuration data - 10 - 1458 bytes
@@ -278,10 +278,10 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-	ZCPP_Header Header;
-	uint16_t sequenceNumber;		// sequence number unique each time the configuration changes
-	uint8_t flags;					// Configuration flags
-	uint8_t ports;					// Number of ports being configured
+  ZCPP_Header Header;
+  uint16_t sequenceNumber;    // sequence number unique each time the configuration changes
+  uint8_t flags;          // Configuration flags
+  uint8_t ports;          // Number of ports being configured
     ZCPP_PortExtraData PortExtraData[1];
 } ZCPP_ExtraData;
 
@@ -291,23 +291,23 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-	ZCPP_Header Header;
-	uint8_t sequenceNumber;			// sequence number matching the data frame sequence number this sync packet is for
+  ZCPP_Header Header;
+  uint8_t sequenceNumber;     // sequence number matching the data frame sequence number this sync packet is for
 } ZCPP_Sync;
 
-// Data - 14 - 1458 bytes
+// Data - 12 - 1458 bytes
 typedef
 #ifndef _MSC_VER
 __attribute__((packed))
 #endif
 struct {
-	ZCPP_Header Header;
-	uint8_t sequenceNumber;			// sequence number matching of the data frame. If multiple packets are needed all packets in the
-									// same frame will have the same sequence number. Frame numbers start at zero and increment and
-									// then go back to zero
-	uint8_t flags;					// data packet flags
-    uint32_t frameAddress;			// where in the zero based data address space the data in this packet belongs
-    uint16_t packetDataLength;		// how many data bytes are in this packet
+  ZCPP_Header Header;
+  uint8_t sequenceNumber;     // sequence number matching of the data frame. If multiple packets are needed all packets in the
+                  // same frame will have the same sequence number. Frame numbers start at zero and increment and
+                  // then go back to zero
+  uint8_t flags;          // data packet flags
+    uint16_t frameAddress;      // where in the zero based data address space the data in this packet belongs
+    uint16_t packetDataLength;    // how many data bytes are in this packet
     uint8_t data[1];
 } ZCPP_Data;
 
@@ -316,33 +316,33 @@ typedef
 __attribute__((packed))
 #endif
 union {
-	// sent discovery
-	ZCPP_Discovery Discovery;
-		// Must lead to a DiscoveryResponse
+  // sent discovery
+  ZCPP_Discovery Discovery;
+    // Must lead to a DiscoveryResponse
 
-	// discovery response
-	ZCPP_DiscoveryResponse DiscoveryResponse;
+  // discovery response
+  ZCPP_DiscoveryResponse DiscoveryResponse;
 
-	// configuration
-	ZCPP_Configuration Configuration;
-		// May optionally lead to a QueryConfigurationResponse
+  // configuration
+  ZCPP_Configuration Configuration;
+    // May optionally lead to a QueryConfigurationResponse
 
-	// extra data
-	ZCPP_ExtraData ExtraData;
-		// May optionally lead to a QueryConfigurationResponse
+  // extra data
+  ZCPP_ExtraData ExtraData;
+    // May optionally lead to a QueryConfigurationResponse
 
-	// query configuration
-	ZCPP_QueryConfiguration QueryConfiguration;
-		// Must lead to a QueryConfigurationResponse
+  // query configuration
+  ZCPP_QueryConfiguration QueryConfiguration;
+    // Must lead to a QueryConfigurationResponse
 
-	// query configuration data response
-	ZCPP_QueryConfigurationResponse QueryConfigurationResponse;
+  // query configuration data response
+  ZCPP_QueryConfigurationResponse QueryConfigurationResponse;
 
-	// data
-	ZCPP_Data Data;
+  // data
+  ZCPP_Data Data;
 
-	// sync
-	ZCPP_Sync Sync;
+  // sync
+  ZCPP_Sync Sync;
 
     uint8_t raw[1458];
 } ZCPP_packet_t;

--- a/ZCPP.h
+++ b/ZCPP.h
@@ -37,6 +37,8 @@
 
 #define ZCPP_CURRENT_PROTOCOL_VERSION 0x00
 
+#define ZCPP_RS_PORT_MASK 0x80
+
 #define ZCPP_VENDOR_FALCON 0x0000
 #define ZCPP_VENDOR_FPP 0x0001
 #define ZCPP_VENDOR_ESPIXELSTICK 0x0002
@@ -57,6 +59,9 @@
 #define ZCPP_DISCOVERY_PROTOCOL_UCS1903 0x00002000
 #define ZCPP_DISCOVERY_PROTOCOL_TM18XX  0x00004000
 #define ZCPP_DISCOVERY_PROTOCOL_RENARD  0x00008000
+#define ZCPP_DISCOVERY_PROTOCOL_LPD8806 0x00010000
+#define ZCPP_DISCOVERY_PROTOCOL_DM412   0x00020000
+#define ZCPP_DISCOVERY_PROTOCOL_P9813   0x00040000
 
 #define ZCPP_PROTOCOL_WS2811 0x00
 #define ZCPP_PROTOCOL_GECE 0x01
@@ -74,6 +79,9 @@
 #define ZCPP_PROTOCOL_UCS1903 0x0D
 #define ZCPP_PROTOCOL_TM18XX 0x0E
 #define ZCPP_PROTOCOL_RENARD 0x0F
+#define ZCPP_PROTOCOL_LPD8806 0x10
+#define ZCPP_PROTOCOL_DM412   0x11
+#define ZCPP_PROTOCOL_P9813   0x12
 
 // when ZCPP_DISCOVERY_FLAG_SEND_DATA_AS_MULTICAST is set the controllers IP is slightly ignored
 // if controller IP is 10.10.10.10 then the data will be multicast to 224.0.31.10 ... ie the last octet is added
@@ -109,43 +117,43 @@
 #define ZCPP_DATA_FLAG_LAST 0x80
 
 inline uint8_t ZCPP_GetSmartRemote(uint8_t string) {
-  return (string & ZCPP_SMART_REMOTE_MASK) >> 6;
+	return (string & ZCPP_SMART_REMOTE_MASK) >> 6;
 }
 
 inline uint8_t ZCPP_GetStringNumber(uint8_t string) {
-  return (string & ZCPP_STRING_NUMBER_MASK);
+	return (string & ZCPP_STRING_NUMBER_MASK);
 }
 
 inline bool ZCPP_IsReversed(uint8_t directionColourOrder) {
-  return (directionColourOrder & ZCPP_REVERSE_MASK) != 0;
+	return (directionColourOrder & ZCPP_REVERSE_MASK) != 0;
 }
 
 inline uint8_t ZCPP_GetColourOrder(uint8_t directionColourOrder) {
-  return directionColourOrder & ZCPP_COLOUR_ORDER_MASK;
+	return directionColourOrder & ZCPP_COLOUR_ORDER_MASK;
 }
 
 inline float ZCPP_GetGamma(uint8_t gamma) {
-  return static_cast<float>(gamma) / 10.0;
+	return static_cast<float>(gamma) / 10.0;
 }
 
 inline uint8_t ZCPP_ConvertDiscoveryProtocolToProtocol(uint32_t discoveryProtocol) {
-  uint8_t res = 0x00;
-  discoveryProtocol = discoveryProtocol > 1;
-  while (discoveryProtocol != 0)  {
-    res++;
-    discoveryProtocol = discoveryProtocol > 1;
-  }
-  return res;
+	uint8_t res = 0x00;
+	discoveryProtocol = discoveryProtocol > 1;
+	while (discoveryProtocol != 0) 	{
+		res++;
+		discoveryProtocol = discoveryProtocol > 1;
+	}
+	return res;
 }
 
 inline uint32_t ZCPP_ConvertProtocolToDiscoveryProtocol(uint8_t protocol)
 {
-  uint32_t res = 0x00000001;
-  while (protocol != 0)   {
-    protocol--;
-    res = res << 1;
-  }
-  return res;
+	uint32_t res = 0x00000001;
+	while (protocol != 0) 	{
+		protocol--;
+		res = res << 1;
+	}
+	return res;
 }
 
 const uint8_t ZCPP_token[4] = {'Z', 'C', 'P', 'P'};
@@ -161,9 +169,9 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-  uint8_t token[4];       // Always ZCPP
-  uint8_t type;       // packet type
-  uint8_t protocolVersion;  // version of the protocol
+	uint8_t token[4]; 			// Always ZCPP
+	uint8_t type;				// packet type
+	uint8_t protocolVersion;	// version of the protocol
 } ZCPP_Header;
 
 // Discovery Request - 8 bytes
@@ -172,9 +180,9 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-  ZCPP_Header Header;
-  uint8_t minProtocolVersion; // The minimum version of the protocol the requester supports
-  uint8_t maxProtocolVersion; // The maximum version of the protocol the requester supports
+	ZCPP_Header Header;
+	uint8_t minProtocolVersion; // The minimum version of the protocol the requester supports
+	uint8_t maxProtocolVersion; // The maximum version of the protocol the requester supports
 } ZCPP_Discovery;
 
 // Discovery Response - 88 bytes
@@ -183,25 +191,25 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-  ZCPP_Header Header;
-  uint8_t minProtocolVersion; // The minimum version of the protocol the controller supports
-  uint8_t maxProtocolVersion; // The maximum version of the protocol the controller supports
-  uint16_t vendor;      // The vendor of the controller
-  uint16_t model;       // A vendor specific model code
-  char firmwareVersion[12]; // A string of up to 12 characters which is the firmware version as a string. It does not
-                // need to be null terminated but should be null filled if all 12 characters are not used
-  uint8_t macAddress[6];    // The controllers mac Address
+	ZCPP_Header Header;
+	uint8_t minProtocolVersion; // The minimum version of the protocol the controller supports
+	uint8_t maxProtocolVersion; // The maximum version of the protocol the controller supports
+	uint16_t vendor;			// The vendor of the controller
+	uint16_t model;				// A vendor specific model code
+	char firmwareVersion[12];	// A string of up to 12 characters which is the firmware version as a string. It does not
+								// need to be null terminated but should be null filled if all 12 characters are not used
+	uint8_t macAddress[6];		// The controllers mac Address
     uint8_t filler1[2];
-  uint32_t ipv4Address;   // The controllers IP V4 IP Address
-  uint32_t ipv4Mask;      // The controllers IP V4 Subnet Mask
-  char userControllerName[32];// Up to 32 characters of user controller name
+	uint32_t ipv4Address;		// The controllers IP V4 IP Address
+	uint32_t ipv4Mask;			// The controllers IP V4 Subnet Mask
+	char userControllerName[32];// Up to 32 characters of user controller name
     uint32_t maxTotalChannels;  // Maximum number of channels that the controller will accept. This may not just be the sum
                                 // of all port channels as the controller may have some global limits
-    uint8_t pixelPorts;     // Number of pixel ports supported by the controller
-  uint8_t rsPorts;      // Number of RSxxx ports supported by the controller
-  uint16_t channelsPerPixelPort; // Maximum number of channels each pixel port can accept
-  uint16_t channelsPerRSPort; // Maximum number of channels each RSxxx port can accept
-    uint16_t flags;       // Discovery Flags
+    uint8_t pixelPorts;			// Number of pixel ports supported by the controller
+	uint8_t rsPorts;			// Number of RSxxx ports supported by the controller
+	uint16_t channelsPerPixelPort; // Maximum number of channels each pixel port can accept
+	uint16_t channelsPerRSPort; // Maximum number of channels each RSxxx port can accept
+    uint16_t flags;				// Discovery Flags
     uint32_t protocolsSupported; // Bitmask of all supported protocols
 } ZCPP_DiscoveryResponse;
 
@@ -211,16 +219,16 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-  uint8_t port;         // zero based port that is being configured
-  uint8_t string;         // smart remote and virtual string number within port
-    uint16_t startChannel;      // zero based start channel within the ZCPP data space
-  uint16_t channels;        // number of channels to send out this port
-    uint8_t protocol;       // port protocol
-    uint8_t grouping;       // pixel grouping on this port. If 2 then channels 123456789 becomes 123123456456789789
-  uint8_t directionColourOrder;   // should data be reversed and what is the pixel colour order
-  uint8_t nullPixels;       // number of null pixels at the start of this string
-  uint8_t brightness;       // 0-100 brightness
-  uint8_t gamma;          // Gamma * 10
+	uint8_t port;					// zero based port that is being configured
+	uint8_t string;					// smart remote and virtual string number within port
+    uint16_t startChannel;			// zero based start channel within the ZCPP data space
+	uint16_t channels;				// number of channels to send out this port
+    uint8_t protocol;				// port protocol
+    uint8_t grouping;				// pixel grouping on this port. If 2 then channels 123456789 becomes 123123456456789789
+	uint8_t directionColourOrder;   // should data be reversed and what is the pixel colour order
+	uint8_t nullPixels;				// number of null pixels at the start of this string
+	uint8_t brightness;				// 0-100 brightness
+	uint8_t gamma;					// Gamma * 10
 } ZCPP_PortConfig;
 
 // Configuration - 42 - 1442 bytes
@@ -229,12 +237,14 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-  ZCPP_Header Header;
-  uint16_t sequenceNumber;    // sequence number unique each time the configuration changes
-  char userControllerName[32];  // Up to 32 characters of user controller name
-  uint8_t flags;          // Configuration flags
-  uint8_t ports;          // Number of ports being configured
-    ZCPP_PortConfig PortConfig[1];    // Up to 100 of them
+	ZCPP_Header Header;
+	uint16_t sequenceNumber;		// sequence number unique each time the configuration changes
+	char userControllerName[32];	// Up to 32 characters of user controller name
+	uint8_t flags;					// Configuration flags
+    uint8_t priority;               // priority of this source
+    uint8_t filler1;
+    uint8_t ports;					// Number of ports being configured
+    ZCPP_PortConfig PortConfig[1];		// Up to 100 of them
 } ZCPP_Configuration;
 
 // Query Configuration Response 42 - 1442 bytes
@@ -243,12 +253,12 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-  ZCPP_Header Header;
-  uint16_t sequenceNumber;    // sequence number unique each time the configuration changes
-  char userControllerName[32];  // Up to 32 characters of user controller name
-  uint8_t flags;          // Configuration result flags
-  uint8_t ports;          // Number of ports configured
-    ZCPP_PortConfig PortConfig[1];    // Up to 100 of them
+	ZCPP_Header Header;
+	uint16_t sequenceNumber;		// sequence number unique each time the configuration changes
+	char userControllerName[32];	// Up to 32 characters of user controller name
+	uint8_t flags;					// Configuration result flags
+	uint8_t ports;					// Number of ports configured
+    ZCPP_PortConfig PortConfig[1];		// Up to 100 of them
 } ZCPP_QueryConfigurationResponse;
 
 // QueryConfiguration - 6 bytes
@@ -257,7 +267,7 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-  ZCPP_Header Header;
+	ZCPP_Header Header;
 } ZCPP_QueryConfiguration;
 
 // Extra port data - 3 - 1458 bytes
@@ -266,10 +276,10 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-  uint8_t port;         // zero based port that is being configured
-  uint8_t string;         // smart remote and virtual string number within port
-  uint8_t descriptionLength;    // length of the description which must fit entirely within this ethernet frame
-    char description[1];        // the port description
+	uint8_t port;					// zero based port that is being configured
+	uint8_t string;					// smart remote and virtual string number within port
+	uint8_t descriptionLength;		// length of the description which must fit entirely within this ethernet frame
+    char description[1];				// the port description
 } ZCPP_PortExtraData;
 
 // Extra port configuration data - 10 - 1458 bytes
@@ -278,10 +288,12 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-  ZCPP_Header Header;
-  uint16_t sequenceNumber;    // sequence number unique each time the configuration changes
-  uint8_t flags;          // Configuration flags
-  uint8_t ports;          // Number of ports being configured
+	ZCPP_Header Header;
+	uint16_t sequenceNumber;		// sequence number unique each time the configuration changes
+	uint8_t flags;					// Configuration flags
+    uint8_t priority;               // priority of this source
+    uint8_t filler1;
+    uint8_t ports;					// Number of ports being configured
     ZCPP_PortExtraData PortExtraData[1];
 } ZCPP_ExtraData;
 
@@ -291,23 +303,26 @@ typedef
 __attribute__((packed))
 #endif
 struct {
-  ZCPP_Header Header;
-  uint8_t sequenceNumber;     // sequence number matching the data frame sequence number this sync packet is for
+	ZCPP_Header Header;
+	uint8_t sequenceNumber;			// sequence number matching the data frame sequence number this sync packet is for
 } ZCPP_Sync;
 
-// Data - 12 - 1458 bytes
+#define ZCPP_DATA_HEADER_SIZE 13
+
+// Data - 13 - 1458 bytes
 typedef
 #ifndef _MSC_VER
 __attribute__((packed))
 #endif
 struct {
-  ZCPP_Header Header;
-  uint8_t sequenceNumber;     // sequence number matching of the data frame. If multiple packets are needed all packets in the
-                  // same frame will have the same sequence number. Frame numbers start at zero and increment and
-                  // then go back to zero
-  uint8_t flags;          // data packet flags
-    uint16_t frameAddress;      // where in the zero based data address space the data in this packet belongs
-    uint16_t packetDataLength;    // how many data bytes are in this packet
+	ZCPP_Header Header;
+	uint8_t sequenceNumber;			// sequence number matching of the data frame. If multiple packets are needed all packets in the
+									// same frame will have the same sequence number. Frame numbers start at zero and increment and
+									// then go back to zero
+	uint8_t flags;					// data packet flags
+    uint16_t frameAddress;			// where in the zero based data address space the data in this packet belongs
+    uint16_t packetDataLength;		// how many data bytes are in this packet
+    uint8_t priority;               // priority of this source
     uint8_t data[1];
 } ZCPP_Data;
 
@@ -316,33 +331,33 @@ typedef
 __attribute__((packed))
 #endif
 union {
-  // sent discovery
-  ZCPP_Discovery Discovery;
-    // Must lead to a DiscoveryResponse
+	// sent discovery
+	ZCPP_Discovery Discovery;
+		// Must lead to a DiscoveryResponse
 
-  // discovery response
-  ZCPP_DiscoveryResponse DiscoveryResponse;
+	// discovery response
+	ZCPP_DiscoveryResponse DiscoveryResponse;
 
-  // configuration
-  ZCPP_Configuration Configuration;
-    // May optionally lead to a QueryConfigurationResponse
+	// configuration
+	ZCPP_Configuration Configuration;
+		// May optionally lead to a QueryConfigurationResponse
 
-  // extra data
-  ZCPP_ExtraData ExtraData;
-    // May optionally lead to a QueryConfigurationResponse
+	// extra data
+	ZCPP_ExtraData ExtraData;
+		// May optionally lead to a QueryConfigurationResponse
 
-  // query configuration
-  ZCPP_QueryConfiguration QueryConfiguration;
-    // Must lead to a QueryConfigurationResponse
+	// query configuration
+	ZCPP_QueryConfiguration QueryConfiguration;
+		// Must lead to a QueryConfigurationResponse
 
-  // query configuration data response
-  ZCPP_QueryConfigurationResponse QueryConfigurationResponse;
+	// query configuration data response
+	ZCPP_QueryConfigurationResponse QueryConfigurationResponse;
 
-  // data
-  ZCPP_Data Data;
+	// data
+	ZCPP_Data Data;
 
-  // sync
-  ZCPP_Sync Sync;
+	// sync
+	ZCPP_Sync Sync;
 
     uint8_t raw[1458];
 } ZCPP_packet_t;

--- a/ZCPP.h
+++ b/ZCPP.h
@@ -1,0 +1,415 @@
+/*
+* ZCPP.h
+*
+* Project: Official ZCPP Protocol Header File
+* Copyright (c) 2019 Keith Westley
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*/
+
+#ifndef ZCPP_H
+#define ZCPP_H
+
+#define ZCPP_MULTICAST_ADDRESS "224.0.30.5"
+#define ZCPP_MULTICAST_DATA_ADDRESS "224.0.31."
+
+// Defaults
+#define ZCPP_PORT 30005
+
+// Packet Type Codes
+#define ZCPP_TYPE_DISCOVERY 0x00
+#define ZCPP_TYPE_DISCOVERY_RESPONSE 0x01
+#define ZCPP_TYPE_CONFIG 0x0A
+#define ZCPP_TYPE_EXTRA_DATA 0x0B
+#define ZCPP_TYPE_QUERY_CONFIG 0x0C
+#define ZCPP_TYPE_QUERY_CONFIG_RESPONSE 0x0D
+#define ZCPP_TYPE_DATA 0x14
+#define ZCPP_TYPE_SYNC 0x15
+
+#define ZCPP_CURRENT_PROTOCOL_VERSION 0x00
+
+#define ZCPP_VENDOR_FALCON 0x0000
+#define ZCPP_VENDOR_FPP 0x0001
+#define ZCPP_VENDOR_ESPIXELSTICK 0x0002
+
+#define ZCPP_DISCOVERY_PROTOCOL_WS2811 0x00000001
+#define ZCPP_DISCOVERY_PROTOCOL_GECE 0x000000002
+#define ZCPP_DISCOVERY_PROTOCOL_DMX 0x000000004
+#define ZCPP_DISCOVERY_PROTOCOL_LX1203 0x00000008
+#define ZCPP_DISCOVERY_PROTOCOL_TLS3001 0x00000010
+#define ZCPP_DISCOVERY_PROTOCOL_LPD6803 0x00000020
+#define ZCPP_DISCOVERY_PROTOCOL_WS2801 0x00000040
+#define ZCPP_DISCOVERY_PROTOCOL_SM16716 0x00000080
+#define ZCPP_DISCOVERY_PROTOCOL_MB16020 0x00000100
+#define ZCPP_DISCOVERY_PROTOCOL_MY9231 0x00000200
+#define ZCPP_DISCOVERY_PROTOCOL_APA102 0x00000400
+#define ZCPP_DISCOVERY_PROTOCOL_MY9221 0x00000800
+#define ZCPP_DISCOVERY_PROTOCOL_SK6812 0x00001000
+#define ZCPP_DISCOVERY_PROTOCOL_UCS1903 0x00002000
+#define ZCPP_DISCOVERY_PROTOCOL_TM18XX 0x00004000
+#define ZCPP_DISCOVERY_PROTOCOL_RENARD 0x00008000
+
+#define ZCPP_PROTOCOL_WS2811 0x00
+#define ZCPP_PROTOCOL_GECE 0x01
+#define ZCPP_PROTOCOL_DMX 0x02
+#define ZCPP_PROTOCOL_LX1203 0x03
+#define ZCPP_PROTOCOL_TLS3001 0x04
+#define ZCPP_PROTOCOL_LPD6803 0x05
+#define ZCPP_PROTOCOL_WS2801 0x06
+#define ZCPP_PROTOCOL_SM16716 0x07
+#define ZCPP_PROTOCOL_MB16020 0x08
+#define ZCPP_PROTOCOL_MY9231 0x09
+#define ZCPP_PROTOCOL_APA102 0x0A
+#define ZCPP_PROTOCOL_MY9221 0x0B
+#define ZCPP_PROTOCOL_SK6812 0x0C
+#define ZCPP_PROTOCOL_UCS1903 0x0D
+#define ZCPP_PROTOCOL_TM18XX 0x0E
+#define ZCPP_PROTOCOL_RENARD 0x0F
+
+// when ZCPP_DISCOVERY_FLAG_SEND_DATA_AS_MULTICAST is set the controllers IP is slightly ignored
+// if controller IP is 10.10.10.10 then the data will be multicast to 224.0.31.10 ... ie the last octet is added
+// to ZCPP_MULTICAST_DATA_ADDRESS
+#define ZCPP_DISCOVERY_FLAG_SEND_DATA_AS_MULTICAST 0x02
+#define ZCPP_DISCOVERY_FLAG_CONFIGURATION_LOCKED 0x04
+#define ZCPP_DISCOVERY_FLAG_SUPPORTS_VIRTUAL_STRINGS 0x08
+#define ZCPP_DISCOVERY_FLAG_SUPPORTS_SMART_REMOTES 0x10
+
+#define ZCPP_SMART_REMOTE_MASK 0xC0
+#define ZCPP_STRING_NUMBER_MASK 0x3F
+
+#define ZCPP_REVERSE_MASK 0x80
+#define ZCPP_COLOUR_ORDER_MASK 0x7
+
+#define ZCPP_COLOUR_ORDER_RGB 0x00
+#define ZCPP_COLOUR_ORDER_RBG 0x01
+#define ZCPP_COLOUR_ORDER_GRB 0x02
+#define ZCPP_COLOUR_ORDER_GBR 0x03
+#define ZCPP_COLOUR_ORDER_BRG 0x04
+#define ZCPP_COLOUR_ORDER_BGR 0x05
+
+#define ZCPP_CONFIG_FLAG_QUERY_CONFIGURATION_RESPONSE_REQUIRED 0x10 
+#define ZCPP_CONFIG_FLAG_FIRST 0x40 
+#define ZCPP_CONFIG_FLAG_LAST 0x80 
+
+#define ZCPP_CONFIG_MAX_PORT_PER_PACKET 100
+
+#define ZCPP_CONFIGURATION_QUERY_ERRORS 0x01
+
+#define ZCPP_DATA_FLAG_SYNC_WILL_BE_SENT 0x01
+#define ZCPP_DATA_FLAG_FIRST 0x40
+#define ZCPP_DATA_FLAG_LAST 0x80
+
+inline uint8_t ZCPP_GetSmartRemote(uint8_t string) {
+	return (string & ZCPP_SMART_REMOTE_MASK) >> 6;
+}
+
+inline uint8_t ZCPP_GetStringNumber(uint8_t string) {
+	return (string & ZCPP_STRING_NUMBER_MASK);
+}
+
+inline bool ZCPP_IsReversed(uint8_t directionColourOrder) {
+	return (directionColourOrder & ZCPP_REVERSE_MASK) != 0;
+}
+
+inline uint8_t ZCPP_GetColourOrder(uint8_t directionColourOrder) {
+	return directionColourOrder & ZCPP_COLOUR_ORDER_MASK;
+}
+
+inline float ZCPP_GetGamma(uint8_t gamma) {
+	return static_cast<float>(gamma) / 10.0;
+}
+
+inline uint8_t ZCPP_ConvertDiscoveryProtocolToProtocol(uint32_t discoveryProtocol) {
+	uint8_t res = 0x00;
+	discoveryProtocol = discoveryProtocol > 1;
+	while (discoveryProtocol != 0) 	{
+		res++;
+		discoveryProtocol = discoveryProtocol > 1;
+	}
+	return res;
+}
+
+inline uint32_t ZCPP_ConvertProtocolToDiscoveryProtocol(uint8_t protocol)
+{
+	uint32_t res = 0x00000001;
+	while (protocol != 0) 	{
+		protocol--;
+		res = res << 1;
+	}
+	return res;
+}
+
+const uint8_t ZCPP_token[4] = {'Z', 'C', 'P', 'P'};
+
+#ifdef _MSC_VER
+#pragma pack(push)
+#pragma pack(1)
+#endif
+
+// Common header across all packet types - 6 bytes
+typedef 
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+struct {
+	uint8_t token[4]; 			// Always ZCPP
+	uint8_t type;				// packet type
+	uint8_t protocolVersion;	// version of the protocol
+} ZCPP_Header;
+
+// Discovery Request - 8 bytes
+typedef 
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+struct {
+	ZCPP_Header Header;
+	uint8_t minProtocolVersion; // The minimum version of the protocol the requester supports
+	uint8_t maxProtocolVersion; // The maximum version of the protocol the requester supports
+} ZCPP_Discovery;
+
+// Discovery Response - 86 bytes
+typedef 
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+struct {
+	ZCPP_Header Header;
+	uint8_t minProtocolVersion; // The minimum version of the protocol the controller supports
+	uint8_t maxProtocolVersion; // The maximum version of the protocol the controller supports
+	uint16_t vendor;			// The vendor of the controller
+	uint16_t model;				// A vendor specific model code
+	char firmwareVersion[12];	// A string of up to 12 characters which is the firmware version as a string. It does not
+								// need to be null terminated but should be null filled if all 12 characters are not used
+	uint8_t macAddress[6];		// The controllers mac Address
+    uint8_t filler1[2];
+	uint32_t ipv4Address;		// The controllers IP V4 IP Address
+	uint32_t ipv4Mask;			// The controllers IP V4 Subnet Mask
+	char userControllerName[32];// Up to 32 characters of user controller name
+    uint32_t maxTotalChannels;  // Maximum number of channels that the controller will accept. This may not just be the sum
+                                // of all port channels as the controller may have some global limits
+    uint8_t pixelPorts;			// Number of pixel ports supported by the controller
+	uint8_t rsPorts;			// Number of RSxxx ports supported by the controller
+	uint16_t channelsPerPixelPort; // Maximum number of channels each pixel port can accept
+	uint16_t channelsPerRSPort; // Maximum number of channels each RSxxx port can accept
+    uint16_t flags;				// Discovery Flags
+    uint32_t protocolsSupported; // Bitmask of all supported protocols
+} ZCPP_DiscoveryResponse;
+
+// Describes the configuration of a port or virtual string - 14 bytes
+typedef 
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+struct {
+	uint8_t port;					// zero based port that is being configured
+	uint8_t string;					// smart remote and virtual string number within port
+    uint16_t startChannel;			// zero based start channel within the ZCPP data space
+    uint8_t protocol;				// port protocol
+	uint16_t channels;				// number of channels to send out this port
+	uint8_t grouping;				// pixel grouping on this port. If 2 then channels 123456789 becomes 123123456456789789
+	uint8_t directionColourOrder;   // should data be reversed and what is the pixel colour order
+	uint8_t nullPixels;				// number of null pixels at the start of this string
+	uint8_t brightness;				// 0-100 brightness
+	uint8_t gamma;					// Gamma * 10
+} ZCPP_PortConfig;
+
+// Configuration - 42 - 1442 bytes
+typedef 
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+struct {
+	ZCPP_Header Header;
+	uint16_t sequenceNumber;		// sequence number unique each time the configuration changes
+	char userControllerName[32];	// Up to 32 characters of user controller name
+	uint8_t flags;					// Configuration flags
+	uint8_t ports;					// Number of ports being configured
+#ifdef _MSC_VER
+    ZCPP_PortConfig PortConfig[1];		// Up to 100 of them
+#else
+    ZCPP_PortConfig PortConfig[];		// Up to 100 of them
+#endif
+} ZCPP_Configuration;
+
+// Query Configuration Response 42 - 1442 bytes
+typedef 
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+struct {
+	ZCPP_Header Header;
+	uint16_t sequenceNumber;		// sequence number unique each time the configuration changes
+	char userControllerName[32];	// Up to 32 characters of user controller name
+	uint8_t flags;					// Configuration result flags
+	uint8_t ports;					// Number of ports configured
+#ifdef _MSC_VER
+    ZCPP_PortConfig PortConfig[1];		// Up to 100 of them
+#else
+    ZCPP_PortConfig PortConfig[];		// Up to 100 of them
+#endif
+} ZCPP_QueryConfigurationResponse;
+
+// QueryConfiguration - 6 bytes
+typedef 
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+struct {
+	ZCPP_Header Header;
+} ZCPP_QueryConfiguration;
+
+// Extra port data - 3 - 1490 bytes
+typedef 
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+struct {
+	uint8_t port;					// zero based port that is being configured
+	uint8_t string;					// smart remote and virtual string number within port
+	uint8_t descriptionLength;		// length of the description which must fit entirely within this ethernet frame
+#ifdef _MSC_VER
+    char description[1];				// the port description
+#else
+    char description[];				// the port description
+#endif
+} ZCPP_PortExtraData;
+
+// Extra port configuration data - 10 - 1500 bytes
+typedef 
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+struct {
+	ZCPP_Header Header;
+	uint16_t sequenceNumber;		// sequence number unique each time the configuration changes
+	uint8_t flags;					// Configuration flags
+	uint8_t ports;					// Number of ports being configured
+#ifdef _MSC_VER
+    ZCPP_PortExtraData PortExtraData[1];
+#else
+    ZCPP_PortExtraData PortExtraData[];
+#endif
+} ZCPP_ExtraData;
+
+// Sync - 7 bytes
+typedef 
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+struct {
+	ZCPP_Header Header;
+	uint8_t sequenceNumber;			// sequence number matching the data frame sequence number this sync packet is for
+} ZCPP_Sync;
+
+// Data - 14 - 1500 bytes
+typedef 
+#ifndef _MSC_VER
+__attribute__((packed)) 
+#endif
+struct {
+	ZCPP_Header Header;
+	uint8_t sequenceNumber;			// sequence number matching of the data frame. If multiple packets are needed all packets in the
+									// same frame will have the same sequence number. Frame numbers start at zero and increment and 
+									// then go back to zero
+	uint8_t flags;					// data packet flags
+    uint32_t frameAddress;			// where in the zero based data address space the data in this packet belongs
+    uint16_t packetDataLength;		// how many data bytes are in this packet
+#ifdef _MSC_VER
+    uint8_t data[1];
+#else
+    uint8_t data[];
+#endif
+} ZCPP_Data;
+
+typedef
+#ifndef _MSC_VER
+__attribute__((packed))
+#endif
+union {
+	// sent discovery
+	ZCPP_Discovery Discovery;
+		// Must lead to a DiscoveryResponse
+	
+	// discovery response
+	ZCPP_DiscoveryResponse DiscoveryResponse;
+	
+	// configuration
+	ZCPP_Configuration Configuration;
+		// May optionally lead to a QueryConfigurationResponse
+
+	// extra data
+	ZCPP_ExtraData ExtraData;
+		// May optionally lead to a QueryConfigurationResponse
+
+	// query configuration
+	ZCPP_QueryConfiguration QueryConfiguration;
+		// Must lead to a QueryConfigurationResponse
+
+	// query configuration data response
+	ZCPP_QueryConfigurationResponse QueryConfigurationResponse;
+
+	// data
+	ZCPP_Data Data;
+
+	// sync
+	ZCPP_Sync Sync;
+
+    uint8_t raw[1500];
+} ZCPP_packet_t;
+
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
+
+inline uint16_t ZCPP_ExtraDataUsed(ZCPP_packet_t& packet) {
+    uint16_t used = 10;
+    ZCPP_PortExtraData* p = packet.ExtraData.PortExtraData;
+    for (int i = 0; i < packet.ExtraData.ports; i++)
+    {
+        used += 3;
+        used += p->descriptionLength;
+        p = (ZCPP_PortExtraData*)((uint8_t*)p + 3 + p->descriptionLength);
+    }
+    return used;
+}
+
+inline uint32_t ZCPP_FromWire32(uint32_t value)
+{
+    uint8_t* p = (uint8_t*)&value;
+    return (((uint32_t)(*p)) << 24) + (((uint32_t)*(p + 1)) << 16) + (((uint32_t)*(p + 2)) << 8) + ((uint32_t)*(p + 3));
+}
+
+inline uint16_t ZCPP_FromWire16(uint16_t value)
+{
+    uint8_t* p = (uint8_t*)&value;
+    return (((uint16_t)(*p)) << 8) + (uint16_t)(*(p + 1));
+}
+
+inline uint32_t ZCPP_ToWire32(uint32_t value)
+{
+    uint8_t res[4];
+    res[0] = value >> 24;
+    res[1] = (value & 0xFF0000) >> 16;
+    res[2] = (value & 0xFF00) >> 8;
+    res[3] = value & 0xFF;
+    return *(uint32_t*)res;
+}
+
+inline uint16_t ZCPP_ToWire16(uint32_t value)
+{
+    uint8_t res[2];
+    res[0] = (value & 0xFF00) >> 8;
+    res[1] = value & 0xFF;
+    return *(uint16_t*)res;
+}
+#endif


### PR DESCRIPTION
This is a largely invisible (from a pixel stick UI perspective implementation of Zero Configuration Pixel Protocol coming soon to xLights.

Basically the protocol will be able to:

Discover pixel sticks
Configure pixel sticks entirely from xLights when the show is playing ... no uploads ... just immediate reconfiguration.
It supports the sync protocol separating the sending of data from a single packet which triggers all controllers to display the data at once.