### PR TITLE
Add FPP discovery pings so FPP and xLights can auto-discover pixelsticks

### DIFF
--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -33,6 +33,7 @@ const char passphrase[] = "ENTER_PASSPHRASE_HERE";
 #include <Hash.h>
 #include <SPI.h>
 #include "ESPixelStick.h"
+#include "FPPDiscovery.h"
 #include "EFUpdate.h"
 #include "wshandler.h"
 #include "gamma.h"
@@ -69,6 +70,7 @@ const char LIGHT_OFF[] = "OFF";
 const char CONFIG_FILE[] = "/config.json";
 
 ESPAsyncE131        e131(10);       // ESPAsyncE131 with X buffers
+FPPDiscovery        fppDiscovery(VERSION);   // FPP Discovery Listener
 config_t            config;         // Current configuration
 uint32_t            *seqError;      // Sequence error tracking for each universe
 uint16_t            uniLast = 1;    // Last Universe to listen for
@@ -257,6 +259,7 @@ void setup() {
             LOG_PORT.println(F("*** UNICAST INIT FAILED ****"));
         }
     }
+    fppDiscovery.begin();
 
 /* to be removed, done earlier
     // Configure the outputs
@@ -1187,4 +1190,3 @@ void loop() {
         while (LOG_PORT.read() >= 0);
     }
 }
-

--- a/FPPDiscovery.cpp
+++ b/FPPDiscovery.cpp
@@ -1,0 +1,75 @@
+/*
+* FPPDiscovery.cpp
+
+* Copyright (c) 2019 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*/
+
+#include "FPPDiscovery.h"
+#include <string.h>
+
+
+FPPDiscovery::FPPDiscovery(const char *ver) {
+    version = ver;
+}
+
+
+bool FPPDiscovery::begin() {
+    bool success = false;
+    delay(100);
+
+    IPAddress address = IPAddress(239, 70, 80, 80);  
+    if (udp.listenMulticast(address, FPP_DISCOVERY_PORT)) {
+        udp.onPacket(std::bind(&FPPDiscovery::parsePacket, this,
+                  std::placeholders::_1));
+       success = true;
+    }
+    sendPingPacket();
+    return success;
+}
+
+
+void FPPDiscovery::parsePacket(AsyncUDPPacket _packet) {
+    FPPPingPacket *packet = reinterpret_cast<FPPPingPacket *>(_packet.data());
+    if (packet->packet_type == 0x04 && packet->ping_subtype == 0x01) {
+        //discover ping packet, need to send a ping out
+        sendPingPacket();
+    }
+}
+
+
+void FPPDiscovery::sendPingPacket() {
+    FPPPingPacket packet;
+    packet.header[0] = 'F';
+    packet.header[1] = 'P';
+    packet.header[2] = 'P';
+    packet.header[3] = 'D';
+    packet.packet_type = 0x04;
+    packet.data_len = 214;
+    packet.ping_version = 0x2;
+    packet.ping_subtype = 0x0; // 1 is to "discover" others, we don't need that
+    packet.ping_hardware = 0xC2;  // 0xC2 is assigned for ESPixelStick
+    uint16_t v = (uint16_t)atoi(version);
+    packet.versionMajor = (v >> 8) + ((v & 0xFF) << 8);
+    v = (uint16_t)atoi(&version[2]);
+    packet.versionMinor = (v >> 8) + ((v & 0xFF) << 8);
+    packet.operatingMode = 0x01; // we only support bridge mode
+    uint32_t ip = static_cast<uint32_t>(WiFi.localIP());
+    memcpy(packet.ipAddress, &ip, 4);
+    strcpy(packet.hostName, WiFi.hostname().c_str());
+    strcpy(packet.version, version);
+    strcpy(packet.hardwareType, "ESPixelStick");
+    packet.ranges[0] = 0;
+    udp.broadcastTo((uint8_t*)&packet, 221, FPP_DISCOVERY_PORT);
+}

--- a/FPPDiscovery.h
+++ b/FPPDiscovery.h
@@ -1,0 +1,72 @@
+/*
+* FPPDiscovery.h
+*
+* Project: ESPixelStick - An ESP8266 and E1.31 based pixel driver
+* Copyright (c) 2018 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*/
+
+#ifndef FPPDISCOVERY
+#define FPPDISCOVERY
+
+#ifdef ESP32
+#include <WiFi.h>
+#include <AsyncUDP.h>
+#elif defined (ESP8266)
+#include <ESPAsyncUDP.h>
+#include <ESP8266WiFi.h>
+#include <ESP8266WiFiMulti.h>
+#else
+#error Platform not supported
+#endif
+
+
+#define FPP_DISCOVERY_PORT 32320
+
+typedef union {
+    struct {
+        uint8_t  header[4];  //FPPD
+        uint8_t  packet_type;
+        uint16_t data_len;
+        uint8_t  ping_version;
+        uint8_t  ping_subtype;
+        uint8_t  ping_hardware;
+        uint16_t versionMajor;
+        uint16_t versionMinor;
+        uint8_t  operatingMode;
+        uint8_t  ipAddress[4];
+        char  hostName[65];
+        char  version[41];
+        char  hardwareType[41];
+        char  ranges[41];
+    } __attribute__((packed));
+
+    uint8_t raw[256];
+} FPPPingPacket;
+
+
+class FPPDiscovery {
+  private:
+    const char *version;
+    AsyncUDP udp;
+    void parsePacket(AsyncUDPPacket _packet);
+  public:
+    FPPDiscovery(const char *ver);
+    bool begin();
+    void sendPingPacket();  
+};
+
+
+
+#endif


### PR DESCRIPTION
Simple update to implement just the "Ping" part of the FPP control protocol which is used by FPP and xLights to discover controllers.   With this, xLights will be able to discover pixel sticks and automatically know they are pixel sticks (hardware ID in ping) and configure things optimally without users needing to know much of anything.   FPP will also know it's a pixel stick and will eventually be able to display status info, version, etc...