### PR TITLE
Update FPPDiscovery.cpp to avoid exception/reboot in Soft AP fallback mode

### DIFF
--- a/FPPDiscovery.cpp
+++ b/FPPDiscovery.cpp
@@ -67,7 +67,9 @@ void FPPDiscovery::sendPingPacket() {
     packet.operatingMode = 0x01; // we only support bridge mode
     uint32_t ip = static_cast<uint32_t>(WiFi.localIP());
     memcpy(packet.ipAddress, &ip, 4);
-    strcpy(packet.hostName, WiFi.hostname().c_str());
+    if (WiFi.hostname()) {
+      strcpy(packet.hostName, WiFi.hostname().c_str());
+    }
     strcpy(packet.version, version);
     strcpy(packet.hardwareType, "ESPixelStick");
     packet.ranges[0] = 0;


### PR DESCRIPTION
I came across this while testing the Soft Access Point fallback functionality.  In that scenario, the hostname isn't setup, which causes an exception/reboot when the FPPDiscovery tries to craft a ping packet.

This change protects against an empty (null) hostname in the WiFi class. This will happen "out of the box" when the config file hasn't been setup with a hostname and there isn't one specified in the ESPixelStick.ino setup code, and the Soft AP fallback is configured.

We could default to something in the INO but this is a good change anyway since it will protect folks in case they accidently remove the default from the caller.