### PR TITLE
Add proper support for LittleFS

### DIFF
--- a/EFUpdate.cpp
+++ b/EFUpdate.cpp
@@ -29,6 +29,8 @@
  *
  * Substitute the value here, while not breaking things for people using older SDKs.
  */
+#include <LittleFS.h>
+#define FILESYSTEM LittleFS
 #define U_SPIFFS U_FS
 #endif
 

--- a/ESPixelStick.h
+++ b/ESPixelStick.h
@@ -41,6 +41,14 @@ const char BUILD_DATE[] = __DATE__;
 #include "SerialDriver.h"
 #endif
 
+// LiffleFS and SPIFFS Support
+#if defined(U_FS)
+#include <LittleFS.h>
+#define FILESYSTEM LittleFS
+#else
+#define FILESYSTEM SPIFFS
+#endif
+
 #include "EffectEngine.h"
 
 #define HTTP_PORT       80      /* Default web server port */

--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -154,8 +154,8 @@ void setup() {
     LOG_PORT.println(")");
     LOG_PORT.println(ESP.getFullVersion());
 
-    // Enable SPIFFS
-    if (!SPIFFS.begin())
+    // Enable the filesystem
+    if (!FILESYSTEM.begin())
     {
         LOG_PORT.println("File system did not initialise correctly");
     }
@@ -165,12 +165,12 @@ void setup() {
     }
 
     FSInfo fs_info;
-    if (SPIFFS.info(fs_info))
+    if (FILESYSTEM.info(fs_info))
     {
         LOG_PORT.print("Total bytes in file system: ");
         LOG_PORT.println(fs_info.usedBytes);
 
-        Dir dir = SPIFFS.openDir("/");
+        Dir dir = FILESYSTEM.openDir("/");
         while (dir.next()) {
           LOG_PORT.print(dir.fileName());
           File f = dir.openFile("r");
@@ -182,7 +182,7 @@ void setup() {
         LOG_PORT.println("Failed to read file system details");
     }
     
-    // Load configuration from SPIFFS and set Hostname
+    // Load configuration from filesystem and set Hostname
     loadConfig();
     if (config.hostname)
         WiFi.hostname(config.hostname);
@@ -604,10 +604,10 @@ void initWeb() {
     }, handle_fw_upload).setFilter(ON_STA_FILTER);
 
     // Static Handler
-    web.serveStatic("/", SPIFFS, "/www/").setDefaultFile("index.html");
+    web.serveStatic("/", FILESYSTEM, "/www/").setDefaultFile("index.html");
 
     // Raw config file Handler - but only on station
-//  web.serveStatic("/config.json", SPIFFS, "/config.json").setFilter(ON_STA_FILTER);
+//  web.serveStatic("/config.json", FILESYSTEM, "/config.json").setFilter(ON_STA_FILTER);
 
     web.onNotFound([](AsyncWebServerRequest *request) {
         request->send(404, "text/plain", "Page not found");
@@ -956,7 +956,7 @@ void loadConfig() {
     effects.setFromDefaults();
 
     // Load CONFIG_FILE json. Create and init with defaults if not found
-    File file = SPIFFS.open(CONFIG_FILE, "r");
+    File file = FILESYSTEM.open(CONFIG_FILE, "r");
     if (!file) {
         LOG_PORT.println(F("- No configuration file found."));
         config.ssid = ssid;
@@ -1112,7 +1112,7 @@ void saveConfig() {
     serializeConfig(jsonString, true, true);
 
     // Save Config
-    File file = SPIFFS.open(CONFIG_FILE, "w");
+    File file = FILESYSTEM.open(CONFIG_FILE, "w");
     if (!file) {
         LOG_PORT.println(F("*** Error creating configuration file ***"));
         return;

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Being open source, you are free to use the ESPixelStick firmware on the device o
 Along with the Arduino IDE, you'll need the following software to build this project:
 
 - [Adruino for ESP8266](https://github.com/esp8266/Arduino) - Arduino core for ESP8266
-- [Arduino ESP8266 Filesystem Uploader](https://github.com/esp8266/arduino-esp8266fs-plugin) - Arduino plugin for uploading files to SPIFFS
+- [Arduino ESP8266 Filesystem Uploader](https://github.com/earlephilhower/arduino-esp8266littlefs-plugin) - Arduino plugin for uploading files to LittleFS
 - [gulp](http://gulpjs.com/) - Build system required to process web sources.  Refer to the html [README](html/README.md) for more information.
 
 The following libraries are required:

--- a/wshandler.h
+++ b/wshandler.h
@@ -391,7 +391,7 @@ void handle_fw_upload(AsyncWebServerRequest *request, String filename,
                 String(efupdate.getError()));
         LOG_PORT.println(F("* Upload Finished."));
         efupdate.end();
-        SPIFFS.begin();
+        FILESYSTEM.begin();
         saveConfig();
         reboot = true;
     }


### PR DESCRIPTION
#178 got the code compiling again, however it doesn't actually add support for LittleFS thus data upload with the newer SDK fails. This ensures that LittleFS is used in place of SPIFFS when using the newer SDK and gets the data upload working properly.

@forkineye, not really sure how to update all the Travis stuff, but it will likely need to be updated to produce valid images with the newer SDK.