### PR TITLE
Removed the existing get options mechanism and used a javascript func…

### DIFF
--- a/html/fpp_remote.html
+++ b/html/fpp_remote.html
@@ -1,6 +1,6 @@
 <div id="FPP Remote">
     <legend class="esps-legend">FPP Remote Configuration</legend>
-    <div class="form-group" id="fppremote">
+    <div class="form-group" id="fpp_remote">
 
         <div class="form-group">
             <label class="control-label col-sm-4" for="fseqfilename">FSEQ File To Play:</label>

--- a/html/index.html
+++ b/html/index.html
@@ -5,10 +5,14 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title id="title"></title>
+
         <!-- for local development
         <link rel="stylesheet" type="text/css" href="css/bootstrap.css">
         <link rel="stylesheet" type="text/css" href="style.css">
+        <link rel="stylesheet" href="css/treejs.css" id="treejs_styles">
+        <link rel="stylesheet" href="css/dropzone.css" id="dropzone_styles">
         -->
+
         <link rel="stylesheet" type="text/css" href="esps.css">
 
     </head>
@@ -345,9 +349,6 @@
                 <i><span id="device-id"></span></i>
             </div>
         </footer>
-
-        <link rel="stylesheet" href="css/treejs.css" id="treejs_styles">
-        <link rel="stylesheet" href="css/dropzone.css" id="dropzone_styles">
 
         <!--
         <script type="text/javascript" src="js/dropzone.js"></script>

--- a/src/WebMgr.cpp
+++ b/src/WebMgr.cpp
@@ -399,74 +399,6 @@ void c_WebMgr::GetDeviceOptions ()
 } // GetDeviceOptions
 
 //-----------------------------------------------------------------------------
-void c_WebMgr::GetInputOptions ()
-{
-    // DEBUG_START;
-
-    // set up a framework to get the option data
-    DynamicJsonDocument webJsonDoc (2048);
-
-    if (0 == webJsonDoc.capacity ())
-    {
-        LOG_PORT.println (F("ERROR: Failed to allocate memory for the GetOptions web request response."));
-    }
-
-    // DEBUG_V ("");
-    JsonObject WebOptions        = webJsonDoc.createNestedObject (F ("options"));
-    JsonObject JsonInputOptions  = WebOptions.createNestedObject (F ("input"));
-    // DEBUG_V("");
-
-    // PrettyPrint (WebOptions);
-
-    InputMgr.GetOptions (JsonInputOptions);
-    // DEBUG_V (""); // remove and we crash
-
-    // PrettyPrint (WebOptions);
-
-    // now make it something we can transmit
-    size_t msgOffset = strlen (WebSocketFrameCollectionBuffer);
-    serializeJson (WebOptions, & WebSocketFrameCollectionBuffer[msgOffset], (sizeof(WebSocketFrameCollectionBuffer) - msgOffset));
-
-    // DEBUG_END;
-
-} // GetInputOptions
-
-//-----------------------------------------------------------------------------
-void c_WebMgr::GetOutputOptions ()
-{
-    // DEBUG_START;
-
-    // set up a framework to get the option data
-    DynamicJsonDocument webJsonDoc (2048);
-
-    if (0 == webJsonDoc.capacity ())
-    {
-        LOG_PORT.println (F ("ERROR: Failed to allocate memory for the GetOutputOptions web request response."));
-    }
-
-    // DEBUG_V ("");
-    JsonObject WebOptions = webJsonDoc.createNestedObject (F ("options"));
-    JsonObject JsonOutputOptions = WebOptions.createNestedObject (F ("output"));
-    // DEBUG_V("");
-
-    // PrettyPrint (WebOptions);
-
-    // DEBUG_V (""); // remove and we crash
-
-    OutputMgr.GetOptions (JsonOutputOptions);
-    // DEBUG_V ("");
-
-    // PrettyPrint (WebOptions);
-
-    // now make it something we can transmit
-    size_t msgOffset = strlen (WebSocketFrameCollectionBuffer);
-    serializeJson (WebOptions, &WebSocketFrameCollectionBuffer[msgOffset], (sizeof (WebSocketFrameCollectionBuffer) - msgOffset));
-
-    // DEBUG_END;
-
-} // GetOutputOptions
-
-//-----------------------------------------------------------------------------
 /// Handle Web Service events
 /** Handles all Web Service event types and performs initial parsing of Web Service event data.
  * Text messages that start with 'X' are treated as "Simple" format messages, else they're parsed as JSON.
@@ -1003,20 +935,6 @@ void c_WebMgr::processCmdOpt (JsonObject & jsonCmd)
         {
             // DEBUG_V ("device");
             GetDeviceOptions ();
-            break;
-        }
-
-        if (jsonCmd["opt"] == "input")
-        {
-            // DEBUG_V ("input");
-            GetInputOptions ();
-            break;
-        }
-
-        if (jsonCmd["opt"] == "output")
-        {
-            // DEBUG_V ("output");
-            GetOutputOptions ();
             break;
         }
 

--- a/src/input/InputFPPRemote.cpp
+++ b/src/input/InputFPPRemote.cpp
@@ -55,7 +55,7 @@ void c_InputFPPRemote::Begin()
 {
     // DEBUG_START;
 
-    LOG_PORT.println (String (F ("** 'FPPRemote' Initialization for Input: '")) + InputChannelId + String (F ("' **")));
+    LOG_PORT.println (String (F ("** 'FPP Remote' Initialization for Input: '")) + InputChannelId + String (F ("' **")));
 
     if (true == HasBeenInitialized)
     {

--- a/src/input/InputFPPRemote.h
+++ b/src/input/InputFPPRemote.h
@@ -40,7 +40,7 @@ class c_InputFPPRemote : public c_InputCommon
       void GetConfig (JsonObject& jsonConfig); ///< Get the current config used by the driver
       void GetStatus (JsonObject& jsonStatus);
       void Process ();                         ///< Call from loop(),  renders Input data
-      void GetDriverName (String& sDriverName) { sDriverName = "FPPRemote"; } ///< get the name for the instantiated driver
+      void GetDriverName (String& sDriverName) { sDriverName = "FPP Remote"; } ///< get the name for the instantiated driver
       void SetBufferInfo (uint8_t* BufferStart, uint16_t BufferSize);
 
 private:

--- a/src/input/InputMgr.cpp
+++ b/src/input/InputMgr.cpp
@@ -292,47 +292,6 @@ void c_InputMgr::GetConfig (char* Response)
 } // GetConfig
 
 //-----------------------------------------------------------------------------
-void c_InputMgr::GetOptions (JsonObject& jsonOptions)
-{
-    // DEBUG_START;
-
-    JsonArray jsonChannelsArray = jsonOptions.createNestedArray ("channels");
-
-    // build a list of the current available channels and their input type
-    for (c_InputCommon* currentInput : pInputChannelDrivers)
-    {
-        JsonObject channelOptionData = jsonChannelsArray.createNestedObject ();
-        e_InputChannelIds InputChannelId = currentInput->GetInputChannelId ();
-        channelOptionData[F ("id")] = InputChannelId;
-        channelOptionData[F ("selectedoption")] = currentInput->GetInputType ();
-
-        // DEBUG_V ("");
-        JsonArray jsonOptionsArray = channelOptionData.createNestedArray (F ("list"));
-
-        // Build a list of Valid options for this device
-        for (InputTypeXlateMap_t currentInputType : InputTypeXlateMap)
-        {
-            // DEBUG_V ("");
-            if (InputTypeIsAllowedOnChannel(currentInputType.id, InputChannelId))
-            {
-                // DEBUG_V ("");
-                JsonObject jsonOptionsArrayEntry = jsonOptionsArray.createNestedObject ();
-                jsonOptionsArrayEntry[F ("id")] = int (currentInputType.id);
-                jsonOptionsArrayEntry[F ("name")] = currentInputType.name;
-                // DEBUG_V ("");
-            }
-            else
-            {
-                // DEBUG_V (String("Type: ") + currentInputType.name + String(" not allowed on channel: ") + String(InputChannelId));
-            }
-
-        } // end for each Input type
-    }
-
-    // DEBUG_END;
-} // GetOptions
-
-//-----------------------------------------------------------------------------
 void c_InputMgr::GetStatus (JsonObject& jsonStatus)
 {
     // DEBUG_START;

--- a/src/input/InputMgr.hpp
+++ b/src/input/InputMgr.hpp
@@ -40,7 +40,6 @@ public:
     void GetStatus  (JsonObject & jsonStatus);
     bool SetConfig  (JsonObject & jsonConfig); ///< Set a new config in the driver
     void Process    ();                        ///< Call from loop(),  renders Input data
-    void GetOptions (JsonObject & jsonOptions);
     void SetBufferInfo (uint8_t* BufferStart, uint16_t BufferSize);
     void SetOperationalState (bool Active);
     void ResetBlankTimer ();

--- a/src/output/OutputMgr.hpp
+++ b/src/output/OutputMgr.hpp
@@ -41,7 +41,6 @@ public:
     void GetConfig     (char * Response);
     bool SetConfig     (JsonObject & jsonConfig); ///< Set a new config in the driver
     void GetStatus     (JsonObject & jsonStatus);
-    void GetOptions    (JsonObject & jsonStatus);
     void PauseOutput   (bool PauseTheOutput) { IsOutputPaused = PauseTheOutput; }
     void GetPortCounts (uint16_t& PixelCount, uint16_t& SerialCount) {PixelCount = uint16_t(OutputChannelId_End); SerialCount = min(uint16_t(OutputChannelId_End), uint16_t(2)); }
     uint8_t*  GetBufferAddress ()  { return OutputBuffer; } ///< Get the address of the buffer into which the E1.31 handler will stuff data


### PR DESCRIPTION
…tion to build the options list based on the entries in the configuration file. This saves an additional 1KB of RAM and fixes a delay in displaying the device configuration page (no additional options message is needed). I had noticed that many of the reboots were coming after the get options message was issued by the browser. We no longer issue this message.