### PR TITLE
Create secrets.h

### DIFF
--- a/src/secrets.h
+++ b/src/secrets.h
@@ -1,0 +1,19 @@
+/*
+* secrets.h
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2016 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*/
+/* This space intentionally left blank */


### PR DESCRIPTION
`secrets.h` needs to exist otherwise it will not compile.

Yes, it gets created; but just downloading and attempting to verify if I have all the libraries, it fails.  So for consistency (and because `WiFiMgr.cpp` specifically includes it, VSCode complains it does not exist), I'm adding it here.