### PR TITLE
add mDNS service

### DIFF
--- a/ESPixelStick.ino
+++ b/ESPixelStick.ino
@@ -47,6 +47,7 @@
 
 // Services
 #include "src/service/FPPDiscovery.h"
+#include "src/service/mDNS.hpp"
 
 #ifdef ARDUINO_ARCH_ESP8266
 #include <Hash.h>
@@ -550,6 +551,9 @@ void loop()
     {
         ResetWiFi = false;
         WiFiMgr.reset ();
+        mDNS.Begin(&config);
     }
+
+    mDNS.Update();
 
 } // loop

--- a/src/service/mDNS.cpp
+++ b/src/service/mDNS.cpp
@@ -1,0 +1,62 @@
+/*
+* c_mDNS.cpp
+
+* Copyright (c) 2020 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*/
+
+#include "../ESPixelStick.h"
+
+#include "mDNS.hpp"
+#include "../input/InputMgr.hpp"
+
+#ifdef ARDUINO_ARCH_ESP8266
+#include <ESP8266WiFi.h>
+#include <ESP8266WiFiMulti.h>
+#include <ESP8266mDNS.h>
+#else
+#include <WiFi.h>
+#include <ESPmDNS.h>
+#endif
+
+c_mDNS::c_mDNS()
+{
+    // DEBUG_START;
+    // DEBUG_END;
+}
+
+//-----------------------------------------------------------------------------
+void c_mDNS::Begin(config_t *NewConfig)
+{
+    // DEBUG_START;
+    config = NewConfig;
+
+    do
+    { // Start the mDNS responder for esp8266.local
+        LOG_PORT.println(F("Error setting up MDNS responder!"));
+        delay(2000);
+    } while (!MDNS.begin(config->hostname.c_str()));
+
+    LOG_PORT.println(F("mDNS responder started."));
+    MDNS.addService("fpp", "udp", 32320);
+    MDNS.addService("http", "tcp", 80);
+    // DEBUG_END;
+} // Begin
+
+void c_mDNS::Update()
+{
+    MDNS.update();
+}
+
+c_mDNS mDNS;

--- a/src/service/mDNS.hpp
+++ b/src/service/mDNS.hpp
@@ -1,0 +1,48 @@
+#pragma once
+/*
+* c_mDNS.h
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2018 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*/
+
+#include "../ESPixelStick.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+#include <WiFi.h>
+#include <ESPmDNS.h>
+#elif defined(ARDUINO_ARCH_ESP8266)
+#include <ESP8266WiFi.h>
+#include <ESP8266WiFiMulti.h>
+#include <ESP8266mDNS.h>
+#else
+#error Platform not supported
+#endif
+
+class c_mDNS
+{
+public:
+    c_mDNS();
+    void Begin(config_t *NewConfig);
+    void Update();
+    config_t *GetConfigPtr() { return config; }
+
+private:
+    config_t *config = nullptr; // Current configuration
+
+protected:
+}; // c_mDNS
+
+extern c_mDNS mDNS;


### PR DESCRIPTION
Add mDNS service advertising both **fpp** and **http** services.

```none
❯ dns-sd -B _fpp._udp .
Browsing for _fpp._udp
DATE: ---Thu 31 Dec 2020---
18:30:04.812  ...STARTING...
Timestamp     A/R    Flags  if Domain               Service Type         Instance Name
18:30:04.812  Add        3   4 local.               _fpp._udp.           esps-2ee280

❯ dns-sd -B _http._tcp .
Browsing for _http._tcp
DATE: ---Thu 31 Dec 2020---
18:30:16.458  ...STARTING...
Timestamp     A/R    Flags  if Domain               Service Type         Instance Name
18:30:16.459  Add        3   4 local.               _http._tcp.          esps-2ee280

❯ dns-sd -G v4 esps-2ee280
DATE: ---Thu 31 Dec 2020---
18:32:36.710  ...STARTING...
Timestamp     A/R    Flags if Hostname              Address             TTL
18:32:36.713  Add        2  0 esps-2ee280.local.    10.10.10.200        4502
```


Console Output
```
ESPixelStick v4.0-dev (NOT STABLE)(Dec 31 2020 - 18:17:11)
ESP Version: SDK:2.2.2-dev(38a443e)/Core:2.7.3-3-g2843a5ac=20703003/lwIP:STABLE-2_1_2_RELEASE/glue:1.2-30-g92add50/BearSSL:5c771be
Flash File system initialized.
Listing directory: /
'config.json': 	'294'
'input_config.json': 	'1297'
'output_config.json': 	'1266'
No SD card installed
Configuration file: '/config.json' loaded.
** OutputDisabled Initialization for Chan: 0 **
** OutputDisabled Initialization for Chan: 1 **
Configuration file: '/output_config.json' loaded.

WiFi Entering State: Connecting Using Config Credentials

WiFi Connecting to YOUR_MOM as esps-2ee280
** 'Disabled' Initialization for input: '0' **
** 'Disabled' Initialization for input: '1' **
Configuration file: '/input_config.json' loaded.
- Web Server started on port 80
FPPDiscovery subscribed to broadcast
FPPDiscovery subscribed to multicast: 239.70.80.80
WiFi Reset has been requested
Error setting up MDNS responder!
Error setting up MDNS responder!
Error setting up MDNS responder!
mDNS responder started.

WiFi Entering State: Connecting Using Config Credentials

WiFi Connecting to YOUR_MOM as esps-2ee280
.
WiFi Entering State: Connected To AP
WiFI: ERROR: STATIC SELECTED WITHOUT IP. Using DHCP assigned address
WiFi Connected with IP: 10.10.10.200
```