### PR TITLE
Ignore Python Litter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .doxygen/doc
 secrets.h
 __pycache__
+*.pyc


### PR DESCRIPTION
When running locally, python litters directories with `*.pyc` files which should be ignored.

```
❯ git status
On branch unify
Your branch is up to date with 'origin/unify'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        dist/bin/esptool/serial/__init__.pyc
        dist/bin/esptool/serial/serialposix.pyc
        dist/bin/esptool/serial/serialutil.pyc
        dist/bin/esptool/serial/tools/__init__.pyc
        dist/bin/esptool/serial/tools/list_ports.pyc
        dist/bin/esptool/serial/tools/list_ports_common.pyc
        dist/bin/esptool/serial/tools/list_ports_osx.pyc
        dist/bin/esptool/serial/tools/list_ports_posix.pyc

nothing added to commit but untracked files present (use "git add" to track)
```