### PR TITLE
FPP Fixes and WiFi Config change

### DIFF
--- a/src/FileMgr.hpp
+++ b/src/FileMgr.hpp
@@ -26,7 +26,7 @@
 #   include <LITTLEFS.h>
 #	include <SD.h>
 #	define SDFS SD
-#else if defined(ARDUINO_ARCH_ESP8266)
+#elif defined(ARDUINO_ARCH_ESP8266)
 #   include <LittleFS.h>
 #	include <SDFS.h>
 #   define LITTLEFS LittleFS

--- a/src/WiFiMgr.cpp
+++ b/src/WiFiMgr.cpp
@@ -304,31 +304,31 @@ int c_WiFiMgr::ValidateConfig (config_t* NewConfig)
 
     int response = 0;
 
-    if (!NewConfig->ssid.length ())
+    if (0 == NewConfig->ssid.length ())
     {
-        // NewConfig->ssid = ssid;
-     // DEBUG_V ();
+        NewConfig->ssid = ssid;
+        // DEBUG_V ();
         response++;
     }
 
-    if (!NewConfig->passphrase.length ())
+    if (0 == NewConfig->passphrase.length ())
     {
-        // NewConfig->passphrase = passphrase;
-     // DEBUG_V ();
+        NewConfig->passphrase = passphrase;
+        // DEBUG_V ();
         response++;
     }
 
     if (NewConfig->sta_timeout < 5)
     {
         NewConfig->sta_timeout = CLIENT_TIMEOUT;
-     // DEBUG_V ();
+        // DEBUG_V ();
         response++;
     }
 
     if (NewConfig->ap_timeout < 15)
     {
         NewConfig->ap_timeout = AP_TIMEOUT;
-     // DEBUG_V ();
+        // DEBUG_V ();
         response++;
     }
 

--- a/src/input/InputEffectEngine.hpp
+++ b/src/input/InputEffectEngine.hpp
@@ -120,12 +120,15 @@ private:
 
     uint32_t EffectStep            = 0;            /* Shared mutable effect step counter */
     uint16_t PixelCount            = 0;            /* Number of RGB leds (not channels) */
+    uint16_t MirroredPixelCount    = 0;            /* Number of RGB leds (not channels) */
     uint8_t  ChannelsPerPixel      = 3;
+    uint16_t PixelOffset           = 0;
 
     void setPixel(uint16_t idx,  CRGB color);
     void setRange(uint16_t first, uint16_t len, CRGB color);
     void clearRange(uint16_t first, uint16_t len);
     void setAll(CRGB color);
+    void outputEffectColor (uint16_t pixelId, CRGB outputColor);
 
     CRGB colorWheel(uint8_t pos);
     dCHSV rgb2hsv(CRGB in);

--- a/src/input/InputFPPRemote.cpp
+++ b/src/input/InputFPPRemote.cpp
@@ -44,7 +44,7 @@ c_InputFPPRemote::c_InputFPPRemote (
 //-----------------------------------------------------------------------------
 c_InputFPPRemote::~c_InputFPPRemote ()
 {
-    FseqFileToPlay = Stop_FPP_RemotePlay;
+    FseqFileToPlay = No_FPP_LocalFileToPlay;
     FPPDiscovery.PlayFile (FseqFileToPlay);
     FPPDiscovery.Disable ();
 

--- a/src/input/InputFPPRemotePlayEffect.cpp
+++ b/src/input/InputFPPRemotePlayEffect.cpp
@@ -1,0 +1,64 @@
+/*
+* InputFPPRemotePlayEffect.cpp
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2020 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*   PlayFile object used to parse and play an FSEQ File
+*/
+
+#include "InputFPPRemotePlayEffect.hpp"
+
+//-----------------------------------------------------------------------------
+c_InputFPPRemotePlayEffect::c_InputFPPRemotePlayEffect (String& NameOfPlayFile) :
+    c_InputFPPRemotePlayItem (NameOfPlayFile)
+{
+    // DEBUG_START;
+
+
+    // DEBUG_END;
+} // c_InputFPPRemotePlayEffect
+
+//-----------------------------------------------------------------------------
+c_InputFPPRemotePlayEffect::~c_InputFPPRemotePlayEffect ()
+{
+
+} // ~c_InputFPPRemotePlayEffect
+
+//-----------------------------------------------------------------------------
+void c_InputFPPRemotePlayEffect::Start ()
+{
+    // DEBUG_START;
+
+
+    // DEBUG_END;
+} // Start
+
+//-----------------------------------------------------------------------------
+void c_InputFPPRemotePlayEffect::Stop ()
+{
+    // DEBUG_START;
+
+
+    // DEBUG_END;
+} // Stop
+
+//-----------------------------------------------------------------------------
+void c_InputFPPRemotePlayEffect::Sync (time_t syncTime)
+{
+    // DEBUG_START;
+
+
+    // DEBUG_END;
+} // Sync

--- a/src/input/InputFPPRemotePlayEffect.hpp
+++ b/src/input/InputFPPRemotePlayEffect.hpp
@@ -19,7 +19,7 @@
 *   PlayFile object used to parse and play an effect
 */
 
-#include "../espixelstick.h"
+#include "../ESPixelStick.h"
 #include "InputFPPRemotePlayItem.hpp"
 
 class c_InputFPPRemotePlayEffect : c_InputFPPRemotePlayItem

--- a/src/input/InputFPPRemotePlayEffect.hpp
+++ b/src/input/InputFPPRemotePlayEffect.hpp
@@ -1,0 +1,37 @@
+#pragma once
+/*
+* InputFPPRemotePlayEffect.hpp
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2020 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*   PlayFile object used to parse and play an effect
+*/
+
+#include "../espixelstick.h"
+#include "InputFPPRemotePlayItem.hpp"
+
+class c_InputFPPRemotePlayEffect : c_InputFPPRemotePlayItem
+{
+public:
+    c_InputFPPRemotePlayEffect (String & NameOfPlayFile);
+    ~c_InputFPPRemotePlayEffect ();
+
+    virtual void Start ();
+    virtual void Stop ();
+    virtual void Sync (time_t syncTime);
+
+private:
+
+}; // c_InputFPPRemotePlayEffect

--- a/src/input/InputFPPRemotePlayFile.cpp
+++ b/src/input/InputFPPRemotePlayFile.cpp
@@ -1,0 +1,65 @@
+/*
+* InputFPPRemotePlayFile.cpp
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2020 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*   PlayFile object used to parse and play an FSEQ File
+*/
+
+#include "InputFPPRemotePlayFile.hpp"
+#include "../service/FPPDiscovery.h"
+
+//-----------------------------------------------------------------------------
+c_InputFPPRemotePlayFile::c_InputFPPRemotePlayFile (String& NameOfPlayFile) :
+    c_InputFPPRemotePlayItem (NameOfPlayFile)
+{
+    // DEBUG_START;
+
+
+    // DEBUG_END;
+} // c_InputFPPRemotePlayFile
+
+//-----------------------------------------------------------------------------
+c_InputFPPRemotePlayFile::~c_InputFPPRemotePlayFile ()
+{
+
+} // ~c_InputFPPRemotePlayFile
+
+//-----------------------------------------------------------------------------
+void c_InputFPPRemotePlayFile::Start ()
+{
+    // DEBUG_START;
+
+
+    // DEBUG_END;
+} // Start
+
+//-----------------------------------------------------------------------------
+void c_InputFPPRemotePlayFile::Stop ()
+{
+    // DEBUG_START;
+
+
+    // DEBUG_END;
+} // Stop
+
+//-----------------------------------------------------------------------------
+void c_InputFPPRemotePlayFile::Sync (time_t syncTime)
+{
+    // DEBUG_START;
+
+
+    // DEBUG_END;
+} // Sync

--- a/src/input/InputFPPRemotePlayFile.hpp
+++ b/src/input/InputFPPRemotePlayFile.hpp
@@ -19,7 +19,7 @@
 *   PlayFile object used to parse and play an FSEQ File
 */
 
-#include "../espixelstick.h"
+#include "../ESPixelStick.h"
 #include "InputFPPRemotePlayItem.hpp"
 
 class c_InputFPPRemotePlayFile : c_InputFPPRemotePlayItem

--- a/src/input/InputFPPRemotePlayFile.hpp
+++ b/src/input/InputFPPRemotePlayFile.hpp
@@ -1,0 +1,37 @@
+#pragma once
+/*
+* InputFPPRemotePlayFile.hpp
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2020 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*   PlayFile object used to parse and play an FSEQ File
+*/
+
+#include "../espixelstick.h"
+#include "InputFPPRemotePlayItem.hpp"
+
+class c_InputFPPRemotePlayFile : c_InputFPPRemotePlayItem
+{
+public:
+    c_InputFPPRemotePlayFile (String & NameOfPlayFile);
+    ~c_InputFPPRemotePlayFile ();
+
+    virtual void Start ();
+    virtual void Stop ();
+    virtual void Sync (time_t syncTime);
+
+private:
+
+}; // c_InputFPPRemotePlayFile

--- a/src/input/InputFPPRemotePlayItem.cpp
+++ b/src/input/InputFPPRemotePlayItem.cpp
@@ -1,0 +1,38 @@
+/*
+* InputFPPRemotePlayItem.cpp
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2020 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*   Common Play object use to parse and play a play list or file
+*/
+
+#include <Int64String.h>
+#include "InputFPPRemotePlayItem.hpp"
+
+//-----------------------------------------------------------------------------
+c_InputFPPRemotePlayItem::c_InputFPPRemotePlayItem (String & NameOfPlaylist)
+{
+    // DEBUG_START;
+
+
+    // DEBUG_END;
+} // c_InputFPPRemotePlayItem
+
+//-----------------------------------------------------------------------------
+c_InputFPPRemotePlayItem::~c_InputFPPRemotePlayItem ()
+{
+
+} // ~c_InputFPPRemotePlayItem
+

--- a/src/input/InputFPPRemotePlayItem.hpp
+++ b/src/input/InputFPPRemotePlayItem.hpp
@@ -1,0 +1,37 @@
+#pragma once
+/*
+* InputFPPRemotePlayItem.hpp
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2020 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*   Common Play object use to parse and play a play list or file
+*/
+
+#include "../espixelstick.h"
+
+class c_InputFPPRemotePlayItem
+{
+public:
+    c_InputFPPRemotePlayItem (String & NameOfPlayItem);
+    ~c_InputFPPRemotePlayItem ();
+
+    virtual void Start () = 0;
+    virtual void Stop  () = 0;
+    virtual void Sync  (time_t syncTime) = 0;
+
+private:
+    String PlayItemName;
+
+};

--- a/src/input/InputFPPRemotePlayItem.hpp
+++ b/src/input/InputFPPRemotePlayItem.hpp
@@ -19,7 +19,7 @@
 *   Common Play object use to parse and play a play list or file
 */
 
-#include "../espixelstick.h"
+#include "../ESPixelStick.h"
 
 class c_InputFPPRemotePlayItem
 {

--- a/src/input/InputFPPRemotePlayList.cpp
+++ b/src/input/InputFPPRemotePlayList.cpp
@@ -1,0 +1,65 @@
+/*
+* InputFPPRemotePlayList.cpp
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2020 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*   Playlist object used to parse and play a playlist
+*/
+
+#include "InputFPPRemotePlayList.hpp"
+#include "../service/FPPDiscovery.h"
+
+//-----------------------------------------------------------------------------
+c_InputFPPRemotePlayList::c_InputFPPRemotePlayList (String & NameOfPlaylist) :
+    c_InputFPPRemotePlayItem(NameOfPlaylist)
+{
+    // DEBUG_START;
+
+
+    // DEBUG_END;
+} // c_InputFPPRemotePlayList
+
+//-----------------------------------------------------------------------------
+c_InputFPPRemotePlayList::~c_InputFPPRemotePlayList ()
+{
+
+} // ~c_InputFPPRemotePlayList
+
+//-----------------------------------------------------------------------------
+void c_InputFPPRemotePlayList::Start ()
+{
+    // DEBUG_START;
+
+
+    // DEBUG_END;
+} // Start
+
+//-----------------------------------------------------------------------------
+void c_InputFPPRemotePlayList::Stop ()
+{
+    // DEBUG_START;
+
+
+    // DEBUG_END;
+} // Stop
+
+//-----------------------------------------------------------------------------
+void c_InputFPPRemotePlayList::Sync (time_t syncTime)
+{
+    // DEBUG_START;
+
+
+    // DEBUG_END;
+} // Sync

--- a/src/input/InputFPPRemotePlayList.hpp
+++ b/src/input/InputFPPRemotePlayList.hpp
@@ -19,9 +19,14 @@
 *   Playlist object use to parse and play a playlist
 */
 
-#include "../espixelstick.h"
+#include "../ESPixelStick.h"
 #include "InputFPPRemotePlayItem.hpp"
 
+// forward declaration
+/*****************************************************************************/
+class fsm_PlayList_state;
+
+/*****************************************************************************/
 class c_InputFPPRemotePlayList : c_InputFPPRemotePlayItem
 {
 public:
@@ -34,4 +39,87 @@ public:
 
 private:
 
+
+protected:
+    friend class fsm_PlayList_state_Idle;
+    friend class fsm_PlayList_state_PlayingFile;
+    friend class fsm_PlayList_state_PlayingEffect;
+    friend class fsm_PlayList_state_Paused;
+    friend class fsm_PlayList_state;
+
+    fsm_PlayList_state * pCurrentFsmState = nullptr;
+    uint32_t             FsmTimerPlayStartTime = 0;
+
 }; // c_InputFPPRemotePlayList
+
+/*****************************************************************************/
+/*
+*	Generic fsm base class.
+*/
+/*****************************************************************************/
+/*****************************************************************************/
+class fsm_PlayList_state
+{
+public:
+    virtual void Poll (void) = 0;
+    virtual void Init (c_InputFPPRemotePlayList * Parent) = 0;
+    virtual void GetStateName (String & sName) = 0;
+    virtual void Start (void) = 0;
+    virtual void Stop (void) = 0;
+protected:
+    c_InputFPPRemotePlayList * pInputFPPRemotePlayList;
+
+}; // fsm_PlayList_state
+
+/*****************************************************************************/
+class fsm_PlayList_state_Idle : fsm_PlayList_state
+{
+public:
+    virtual void Poll (void);
+    virtual void Init (c_InputFPPRemotePlayList* Parent);
+    virtual void GetStateName (String& sName);
+    virtual void Start (void);
+    virtual void Stop (void);
+
+}; // fsm_PlayList_state_Idle
+
+/*****************************************************************************/
+class fsm_PlayList_state_PlayingFile : fsm_PlayList_state
+{
+public:
+    virtual void Poll (void);
+    virtual void Init (c_InputFPPRemotePlayList* Parent);
+    virtual void GetStateName (String& sName);
+    virtual void Start (void);
+    virtual void Stop (void);
+
+}; // fsm_PlayList_state_PlayingFile
+
+/*****************************************************************************/
+class fsm_PlayList_state_PlayingEffect : fsm_PlayList_state
+{
+public:
+    virtual void Poll (void);
+    virtual void Init (c_InputFPPRemotePlayList* Parent);
+    virtual void GetStateName (String& sName);
+    virtual void Start (void);
+    virtual void Stop (void);
+
+}; // fsm_PlayList_state_PlayingEffect
+
+/*****************************************************************************/
+class fsm_PlayList_state_Paused : fsm_PlayList_state
+{
+public:
+    virtual void Poll (void);
+    virtual void Init (c_InputFPPRemotePlayList* Parent);
+    virtual void GetStateName (String& sName);
+    virtual void Start (void);
+    virtual void Stop (void);
+
+}; // fsm_PlayList_state_Paused
+
+
+
+
+

--- a/src/input/InputFPPRemotePlayList.hpp
+++ b/src/input/InputFPPRemotePlayList.hpp
@@ -1,0 +1,37 @@
+#pragma once
+/*
+* InputFPPRemotePlayList.hpp
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2020 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*   Playlist object use to parse and play a playlist
+*/
+
+#include "../espixelstick.h"
+#include "InputFPPRemotePlayItem.hpp"
+
+class c_InputFPPRemotePlayList : c_InputFPPRemotePlayItem
+{
+public:
+    c_InputFPPRemotePlayList (String & NameOfPlaylist);
+    ~c_InputFPPRemotePlayList ();
+
+    virtual void Start ();
+    virtual void Stop  ();
+    virtual void Sync  (time_t syncTime);
+
+private:
+
+}; // c_InputFPPRemotePlayList

--- a/src/service/FPPDiscovery.h
+++ b/src/service/FPPDiscovery.h
@@ -32,14 +32,13 @@
 #	error Platform not supported
 #endif
 
-
 #include <ESPAsyncWebServer.h>
 
 class c_FPPDiscovery
 {
 public:
 
-#   define Stop_FPP_RemotePlay "..."
+#   define No_FPP_LocalFileToPlay "..."
 
 private:
 
@@ -52,7 +51,7 @@ private:
     c_FileMgr::FileId fseqFile;
     String fseqName = "";
     String failedFseqName = "";
-    String AutoPlayFileName = Stop_FPP_RemotePlay;
+    String AutoPlayFileName = No_FPP_LocalFileToPlay;
     unsigned long fseqStartMillis = 0;
     int fseqCurrentFrameId = 0;
     uint32_t dataOffset = 0;
@@ -77,6 +76,14 @@ private:
     void StartPlaying      (String & filename, uint32_t frameId);
     bool AllowedToRemotePlayFiles ();
 
+#ifdef ARDUINO_ARCH_ESP8266
+    WiFiEventHandler    wifiConnectHandler;     // WiFi connect handler
+    void onWiFiConnect (const WiFiEventStationModeGotIP& event);
+#else
+    void onWiFiConnect (const WiFiEvent_t event, const WiFiEventInfo_t info);
+#endif
+
+
 public:
     c_FPPDiscovery ();
 
@@ -88,7 +95,7 @@ public:
     void ProcessFile      (AsyncWebServerRequest* request, String filename, size_t index, uint8_t* data, size_t len, bool final);
     void ProcessBody      (AsyncWebServerRequest* request, uint8_t* data, size_t len, size_t index, size_t total);
     void ReadNextFrame    (uint8_t* outputBuffer, uint16_t outputBufferSize);
-    void sendPingPacket    (IPAddress destination = IPAddress(255, 255, 255, 255));
+    void sendPingPacket   (IPAddress destination = IPAddress(255, 255, 255, 255));
     void PlayFile         (String & FileToPlay);
     void Enable           (void);
     void Disable          (void);


### PR DESCRIPTION
Fixed issue in the status response that returned a string when an enum was expected. This caused odd mode reporting including "unknown" mode.

Fixed detection of FPP pings that was broken when the ping requests were seperated due to an endless loop of pings. FPP  sends a specific ping subtype. The remotes need to respond with an alternative sub type that will not trigger the other remote devices to generate pings. The correct fix should have been to send pings from the ESP using the remote device ping sub type.

Fixed remote vs bridge reporting to be aware of FPP settings in the config as well as file selection in the config. Local autoplay still trumps FPP master.

Added ping generation when the WiFi interface declares itself operational. This triggers the Master to talk to us. This fixes a race condition with the initial ping trying to go out before the WiFi is up.

Added copy of default WiFi Creds to config WiFi creds when the config creds are empty.