### PR TITLE
Harmonize on common code

### DIFF
--- a/ESPixelStick.h
+++ b/ESPixelStick.h
@@ -45,7 +45,9 @@ const char BUILD_DATE[] = __DATE__;
 
 #define HTTP_PORT       80      /* Default web server port */
 #define MQTT_PORT       1883    /* Default MQTT port */
-#define DATA_PIN        2       /* Pixel output - GPIO2 (D4 on NodeMCU) */
+#if defined(ESPS_MODE_PIXEL)
+    #define DATA_PIN        2   /* Pixel output - GPIO2 (D4 on NodeMCU) */
+#endif
 #define UNIVERSE_MAX    512     /* Max channels in a DMX Universe */
 #define PIXEL_LIMIT     1360    /* Total pixel limit - 40.85ms for 8 universes */
 #define RENARD_LIMIT    2048    /* Channel limit for serial outputs */

--- a/wshandler.h
+++ b/wshandler.h
@@ -22,10 +22,10 @@
 
 #if defined(ESPS_MODE_PIXEL)
 #include "PixelDriver.h"
-extern PixelDriver  pixels;     // Pixel object
+extern PixelDriver  out_driver;     // Pixel object
 #elif defined(ESPS_MODE_SERIAL)
 #include "SerialDriver.h"
-extern SerialDriver serial;     // Serial object
+extern SerialDriver out_driver;     // Serial object
 #endif
 
 extern EffectEngine effects;    // EffectEngine for test modes
@@ -356,12 +356,12 @@ void procV(uint8_t *data, AsyncWebSocketClient *client) {
     switch (data[1]) {
         case '1': {  // View stream
 #if defined(ESPS_MODE_PIXEL)
-            client->binary(pixels.getData(), config.channel_count);
+            client->binary(out_driver.getData(), config.channel_count);
 #elif defined(ESPS_MODE_SERIAL)
             if (config.serial_type == SerialType::DMX512)
-                client->binary(&serial.getData()[1], config.channel_count);
+                client->binary(&out_driver.getData()[1], config.channel_count);
             else
-                client->binary(&serial.getData()[2], config.channel_count);
+                client->binary(&out_driver.getData()[2], config.channel_count);
 #endif
             break;
         }


### PR DESCRIPTION
Code clean-up. By using a common name for the pixels vs serial drivers, we can remove several instances of #ifdef PIXEL. 
Fewer places to change if/when something other than PIXEL or SERIAL is introduced. (Like .. say.. a bridge to NRF24L01 wireless network). :) 