### PR TITLE
Added preamble support to basic pixel support class

### DIFF
--- a/html/tm1814.html
+++ b/html/tm1814.html
@@ -1,0 +1,166 @@
+<div id="tm1814">
+    <legend class="esps-legend" id="Title">TM1814 Configuration</legend>
+    <div class="has-feedback" id="fg_tm1814">
+        <fieldset id="fs_tm1814">
+            <div class="form-group">
+                <label class="control-label col-sm-2" for="pixel_count">Pixel Count</label>
+                <div class="col-sm-2">
+                    <input type="number" class="form-control is-valid" id="pixel_count" step="1" min="1" max="1200" value="0" required title="Number of pixels" onchange="tm1814_OnChange()">
+                </div>
+                <label class="control-label col-sm-2" for="group_size">Group Size</label>
+                <div class="col-sm-2">
+                    <input type="number" class="form-control is-valid" id="group_size" step="1" min="1" max="1360" value="1" required title="Group every X number of physical pixels together.  Default of 1 is no grouping." onchange="tm1814_OnChange()">
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label class="control-label col-sm-2" for="color_order">Color Order</label>
+                <div class="col-sm-2">
+                    <select class="form-control" id="color_order">
+                        <option value="rgb">RGB</option>
+                        <option value="grb">GRB</option>
+                        <option value="brg">BRG</option>
+                        <option value="rbg">RBG</option>
+                        <option value="gbr">GBR</option>
+                        <option value="bgr">BGR</option>
+                        <option value="rgbw">RGBW</option>
+                        <option value="grbw">GRBW</option>
+                        <option value="brgw">BRGW</option>
+                        <option value="rbgw">RBGW</option>
+                        <option value="gbrw">GBRW</option>
+                        <option value="bgrw">BGRW</option>
+                    </select>
+                </div>
+                <label class="control-label col-sm-2" for="zig_size">Zigzag Count</label>
+                <div class="col-sm-2">
+                    <input type="number" class="form-control is-valid" id="zig_size" step="1" min="0" max="680" value="0" required title="Zigzag every X number of physical pixels." onchange="tm1814_OnChange()">
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label class="control-label col-sm-2" for="gamma">Gamma Value</label>
+                <div class="col-sm-2">
+                    <input type="number" class="form-control is-valid" id="gamma" step="0.1" min="1.0" max="5.0" value="1.0" required title="Recommended value is 2.2. Set to 1.0 to disable." onchange="tm1814_OnChange()">
+                </div>
+
+                <label class="control-label col-sm-2" for="brightness">Brightness (%)</label>
+                <div class="col-sm-2">
+                    <input type="number" class="form-control is-valid" id="brightness" step="1" min="1" max="100" value="100" title="Set brightness as a percentage" onchange="tm1814_OnChange()">
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label class="control-label col-sm-2" for="prependnullcount">Start NULL Count</label>
+                <div class="col-sm-2">
+                    <input type="number" class="form-control is-valid" id="prependnullcount" step="1" min="0" max="100" value="0" title="Number of NULL Pixels to send before Pixel Data" onchange="tm1814_OnChange()">
+                </div>
+                <label class="control-label col-sm-2" for="appendnullcount">End NULL Count</label>
+                <div class="col-sm-2">
+                    <input type="number" class="form-control is-valid" id="appendnullcount" step="1" min="0" max="100" value="0" title="Number of NULL Pixels to send after Pixel Data" onchange="tm1814_OnChange()">
+                </div>
+            </div>
+
+            <div class="form-group">
+                <div class="col-sm-offset-2 col-sm-2">
+                    <div class="checkbox"><label><input type="checkbox" id="showgamma"> Show Gamma Curve</label></div>
+                </div>
+                <label class="control-label col-sm-2" for="interframetime">Inter Frame Time (us)</label>
+                <div class="col-sm-2">
+                    <input type="number" class="form-control is-valid" id="interframetime" step="1" min="300" max="10000" value="300" required title="Number of Micro Seconds between each frame." onchange="tm1814_OnChange()">
+                </div>
+            </div>
+
+            <label class="control-label col-sm-2 hidden AdvancedMode" for="data_pin">GPIO Output</label>
+            <div class="col-sm-2">
+                <input type="number" class="form-control is-valid hidden AdvancedMode" id="data_pin" step="1" min="0" max="64" value="65" required title="GPIO pn which to output data">
+            </div>
+        </fieldset>
+    </div>
+</div>
+
+<div class="col-sm-offset-2 col-sm-8 hidden gammagraph">
+    <svg viewBox="-25 -30 320 320" width="256" height="256" class="chart">
+        <defs>
+            <marker id="arrow" markerWidth="10" markerHeight="10" refX="0" refY="3" orient="auto" markerUnits="strokeWidth">
+                <path d="M0,0 L0,6 L9,3 z" fill="#f00" />
+            </marker>
+        </defs>
+
+        <line x1="0" y1="256" x2="256" y2="256" stroke="#000" stroke-width="2" marker-end="url(#arrow)" />
+        <text x="125" y="275" class="label-title">Input</text>
+
+        <line x1="0" y1="256" x2="0" y2="0" stroke="#000" stroke-width="2" marker-end="url(#arrow)" />
+        <text x="-15" y="120" class="label-title" style="writing-mode: tb;">Output</text>
+
+        <polyline id="cracker"
+                  fill="none"
+                  stroke="#0074d9"
+                  stroke-width="2"
+                  points="" />
+    </svg>
+</div>
+
+<script>
+
+    // Gamma graph
+    $('#tm1814 #showgamma').click(function () {
+        if ($(this).is(':checked')) {
+            $('.gammagraph').removeClass('hidden');
+        } else {
+            $('.gammagraph').addClass('hidden');
+        }
+    });
+
+    // Gamma graph
+    $('#tm1814 #gamma').change(function () {
+        sendGamma();
+    });
+    $('#tm1814 #brightness').change(function () {
+        sendGamma();
+    });
+
+    function sendGamma() {
+        var json = {
+            'pixel': {
+                'gammaVal': parseFloat($('#p_gammaVal').val()),
+                'briteVal': parseFloat($('#p_briteVal').val())
+            }
+        }
+        //    wsEnqueue('S4' + JSON.stringify(json));
+        //    wsEnqueue('G4'); // Get Gamma Table
+    }
+
+    function refreshGamma(data) {
+        var gammaData = JSON.parse(data);
+        var polyline = document.getElementById('cracker');
+        var points = polyline.getAttribute('points');
+
+        points = "";
+        for (X = 0; X < 256; X++) {
+            var Y = 255 - gammaData.gamma[X];
+            points += X + ", " + Y + " ";
+        }
+
+        polyline.setAttribute('points', points);
+    }
+
+    function tm1814_OnChange()
+    {
+        // var NumberOfPixels       = parseInt($('#pixel_count').val());
+        // var BytesPerPixel = $('#color_order option:selected').val().length;
+        // console.info("BytesPerPixel: " + BytesPerPixel);
+        // var NumberOfBytesInFrame = NumberOfPixels * BytesPerPixel;
+        // var PixelBaudRate        = 800000;
+        // var TimePerBit           = 1 / PixelBaudRate;
+        // var BitsPerByte          = 8;
+        // var TimePerByte          = TimePerBit * BitsPerByte; = 0.00001
+        // var InterFrameGap        = parseInt($('#interframetime').val()) / 1000000;
+        // var TimePerFrame         = (TimePerByte * NumberOfBytesInFrame) + InterFrameGap;
+        var TimePerFrame = (0.00001 * (parseInt($('#pixel_count').val()) * $('#color_order option:selected').val().length)) + (parseInt($('#interframetime').val()) / 1000000);
+
+        var rateMs = TimePerFrame * 1000;
+        var hz = 1 / TimePerFrame;
+        $('#refresh').html(Math.ceil(rateMs) + ' ms / ' + Math.floor(hz) + ' fps');
+    } // refreshPixel
+
+</script>

--- a/html/ws2801.html
+++ b/html/ws2801.html
@@ -1,0 +1,166 @@
+<div id="ws2801">
+    <legend class="esps-legend" id="Title">ws2801 Configuration</legend>
+    <div class="has-feedback" id="fg_ws2801">
+        <fieldset id="fs_ws2801">
+            <div class="form-group">
+                <label class="control-label col-sm-2" for="pixel_count">Pixel Count</label>
+                <div class="col-sm-2">
+                    <input type="number" class="form-control is-valid" id="pixel_count" step="1" min="1" max="1200" value="0" required title="Number of pixels" onchange="ws2801_OnChange()">
+                </div>
+                <label class="control-label col-sm-2" for="group_size">Group Size</label>
+                <div class="col-sm-2">
+                    <input type="number" class="form-control is-valid" id="group_size" step="1" min="1" max="1360" value="1" required title="Group every X number of physical pixels together.  Default of 1 is no grouping." onchange="ws2801_OnChange()">
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label class="control-label col-sm-2" for="color_order">Color Order</label>
+                <div class="col-sm-2">
+                    <select class="form-control" id="color_order">
+                        <option value="rgb">RGB</option>
+                        <option value="grb">GRB</option>
+                        <option value="brg">BRG</option>
+                        <option value="rbg">RBG</option>
+                        <option value="gbr">GBR</option>
+                        <option value="bgr">BGR</option>
+                        <option value="rgbw">RGBW</option>
+                        <option value="grbw">GRBW</option>
+                        <option value="brgw">BRGW</option>
+                        <option value="rbgw">RBGW</option>
+                        <option value="gbrw">GBRW</option>
+                        <option value="bgrw">BGRW</option>
+                    </select>
+                </div>
+                <label class="control-label col-sm-2" for="zig_size">Zigzag Count</label>
+                <div class="col-sm-2">
+                    <input type="number" class="form-control is-valid" id="zig_size" step="1" min="0" max="680" value="0" required title="Zigzag every X number of physical pixels." onchange="ws2801_OnChange()">
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label class="control-label col-sm-2" for="gamma">Gamma Value</label>
+                <div class="col-sm-2">
+                    <input type="number" class="form-control is-valid" id="gamma" step="0.1" min="1.0" max="5.0" value="1.0" required title="Recommended value is 2.2. Set to 1.0 to disable." onchange="ws2801_OnChange()">
+                </div>
+
+                <label class="control-label col-sm-2" for="brightness">Brightness (%)</label>
+                <div class="col-sm-2">
+                    <input type="number" class="form-control is-valid" id="brightness" step="1" min="1" max="100" value="100" title="Set brightness as a percentage" onchange="ws2801_OnChange()">
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label class="control-label col-sm-2" for="prependnullcount">Start NULL Count</label>
+                <div class="col-sm-2">
+                    <input type="number" class="form-control is-valid" id="prependnullcount" step="1" min="0" max="100" value="0" title="Number of NULL Pixels to send before Pixel Data" onchange="ws2801_OnChange()">
+                </div>
+                <label class="control-label col-sm-2" for="appendnullcount">End NULL Count</label>
+                <div class="col-sm-2">
+                    <input type="number" class="form-control is-valid" id="appendnullcount" step="1" min="0" max="100" value="0" title="Number of NULL Pixels to send after Pixel Data" onchange="ws2801_OnChange()">
+                </div>
+            </div>
+
+            <div class="form-group">
+                <div class="col-sm-offset-2 col-sm-2">
+                    <div class="checkbox"><label><input type="checkbox" id="showgamma"> Show Gamma Curve</label></div>
+                </div>
+                <label class="control-label col-sm-2" for="interframetime">Inter Frame Time (us)</label>
+                <div class="col-sm-2">
+                    <input type="number" class="form-control is-valid" id="interframetime" step="1" min="300" max="10000" value="300" required title="Number of Micro Seconds between each frame." onchange="ws2801_OnChange()">
+                </div>
+            </div>
+
+            <label class="control-label col-sm-2 hidden AdvancedMode" for="data_pin">GPIO Output</label>
+            <div class="col-sm-2">
+                <input type="number" class="form-control is-valid hidden AdvancedMode" id="data_pin" step="1" min="0" max="64" value="65" required title="GPIO pn which to output data">
+            </div>
+        </fieldset>
+    </div>
+</div>
+
+<div class="col-sm-offset-2 col-sm-8 hidden gammagraph">
+    <svg viewBox="-25 -30 320 320" width="256" height="256" class="chart">
+        <defs>
+            <marker id="arrow" markerWidth="10" markerHeight="10" refX="0" refY="3" orient="auto" markerUnits="strokeWidth">
+                <path d="M0,0 L0,6 L9,3 z" fill="#f00" />
+            </marker>
+        </defs>
+
+        <line x1="0" y1="256" x2="256" y2="256" stroke="#000" stroke-width="2" marker-end="url(#arrow)" />
+        <text x="125" y="275" class="label-title">Input</text>
+
+        <line x1="0" y1="256" x2="0" y2="0" stroke="#000" stroke-width="2" marker-end="url(#arrow)" />
+        <text x="-15" y="120" class="label-title" style="writing-mode: tb;">Output</text>
+
+        <polyline id="cracker"
+                  fill="none"
+                  stroke="#0074d9"
+                  stroke-width="2"
+                  points="" />
+    </svg>
+</div>
+
+<script>
+
+    // Gamma graph
+    $('#ws2801 #showgamma').click(function () {
+        if ($(this).is(':checked')) {
+            $('.gammagraph').removeClass('hidden');
+        } else {
+            $('.gammagraph').addClass('hidden');
+        }
+    });
+
+    // Gamma graph
+    $('#ws2801 #gamma').change(function () {
+        sendGamma();
+    });
+    $('#ws2801 #brightness').change(function () {
+        sendGamma();
+    });
+
+    function sendGamma() {
+        var json = {
+            'pixel': {
+                'gammaVal': parseFloat($('#p_gammaVal').val()),
+                'briteVal': parseFloat($('#p_briteVal').val())
+            }
+        }
+        //    wsEnqueue('S4' + JSON.stringify(json));
+        //    wsEnqueue('G4'); // Get Gamma Table
+    }
+
+    function refreshGamma(data) {
+        var gammaData = JSON.parse(data);
+        var polyline = document.getElementById('cracker');
+        var points = polyline.getAttribute('points');
+
+        points = "";
+        for (X = 0; X < 256; X++) {
+            var Y = 255 - gammaData.gamma[X];
+            points += X + ", " + Y + " ";
+        }
+
+        polyline.setAttribute('points', points);
+    }
+
+    function ws2801_OnChange()
+    {
+        // var NumberOfPixels       = parseInt($('#pixel_count').val());
+        // var BytesPerPixel = $('#color_order option:selected').val().length;
+        // console.info("BytesPerPixel: " + BytesPerPixel);
+        // var NumberOfBytesInFrame = NumberOfPixels * BytesPerPixel;
+        // var PixelBaudRate        = 800000;
+        // var TimePerBit           = 1 / PixelBaudRate;
+        // var BitsPerByte          = 8;
+        // var TimePerByte          = TimePerBit * BitsPerByte; = 0.00001
+        // var InterFrameGap        = parseInt($('#interframetime').val()) / 1000000;
+        // var TimePerFrame         = (TimePerByte * NumberOfBytesInFrame) + InterFrameGap;
+        var TimePerFrame = (0.00001 * (parseInt($('#pixel_count').val()) * $('#color_order option:selected').val().length)) + (parseInt($('#interframetime').val()) / 1000000);
+
+        var rateMs = TimePerFrame * 1000;
+        var hz = 1 / TimePerFrame;
+        $('#refresh').html(Math.ceil(rateMs) + ' ms / ' + Math.floor(hz) + ' fps');
+    } // refreshPixel
+
+</script>

--- a/src/output/OutputMgr.hpp
+++ b/src/output/OutputMgr.hpp
@@ -91,7 +91,9 @@ public:
         OutputType_Servo_PCA9685,
         OutputType_TM1814,
         OutputType_Disabled,
+#ifdef USE_WS2801
         OutputType_WS2801,
+#endif // def USE_WS2801
         OutputType_End, // must be last
         OutputType_Start = OutputType_WS2811,
     };

--- a/src/output/OutputMgr.hpp
+++ b/src/output/OutputMgr.hpp
@@ -67,6 +67,7 @@ public:
         OutputChannelId_RMT_7,
         OutputChannelId_RMT_8,
 #endif // ndef ESP32_CAM
+        OutputChannelId_SPI_1,
 #endif // def ARDUINO_ARCH_ESP32
         OutputChannelId_Relay,
         OutputChannelId_End, // must be last in the list
@@ -90,6 +91,7 @@ public:
         OutputType_Servo_PCA9685,
         OutputType_TM1814,
         OutputType_Disabled,
+        OutputType_WS2801,
         OutputType_End, // must be last
         OutputType_Start = OutputType_WS2811,
     };

--- a/src/output/OutputPixel.cpp
+++ b/src/output/OutputPixel.cpp
@@ -112,6 +112,18 @@ void c_OutputPixel::SetOutputBufferSize (uint16_t NumChannelsAvailable)
 } // SetBufferSize
 
 //----------------------------------------------------------------------------
+void c_OutputPixel::SetPreambleInformation (uint8_t* PreambleStart, uint8_t NewPreambleSize)
+{
+    DEBUG_START;
+
+    pPreamble = PreambleStart;
+    PreambleSize = NewPreambleSize;
+
+    DEBUG_END;
+
+} // SetPreambleInformation
+
+//----------------------------------------------------------------------------
 /* Process the config
 *
 *   needs
@@ -266,6 +278,7 @@ void IRAM_ATTR c_OutputPixel::StartNewFrame ()
     CurrentIntensityIndex   = 0;
     CurrentPrependNullCount = PrependNullCount * numIntensityBytesPerPixel;
     CurrentAppendNullCount  = AppendNullCount  * numIntensityBytesPerPixel;
+    PreambleCurrentCount    = 0;
 
     MoreDataToSend = (0 == pixel_count) ? false : true;
 
@@ -281,6 +294,12 @@ uint8_t IRAM_ATTR c_OutputPixel::GetNextIntensityToSend ()
 
     do // once
     {
+        if (PreambleSize != PreambleCurrentCount)
+        {
+            response = pPreamble[PreambleCurrentCount++];
+            break;
+        }
+
         // Are we prepending NULL data?
         if (CurrentPrependNullCount)
         {

--- a/src/output/OutputPixel.hpp
+++ b/src/output/OutputPixel.hpp
@@ -53,6 +53,7 @@ protected:
 
     IRAM_ATTR void    StartNewFrame ();
     IRAM_ATTR uint8_t GetNextIntensityToSend ();
+    void SetPreambleInformation (uint8_t* PreambleStart, uint8_t PreambleSize);
 
     bool      MoreDataToSend = false;
     uint16_t  InterFrameGapInMicroSec = 300;
@@ -62,6 +63,11 @@ private:
 
     uint8_t*    pNextIntensityToSend = nullptr;     ///< start of output buffer being sent to the UART
     uint16_t    RemainingPixelCount = 0;            ///< Used by ISR to determine how much more data to send
+
+    uint8_t*    pPreamble = nullptr;
+    uint8_t     PreambleSize = 0;
+    uint8_t     PreambleCurrentCount = 0;
+
     uint8_t     brightness = 100;                   ///< brightness to use
     uint16_t    zig_size = 1;                       ///< Zigsize count - 0 = no zigzag
     uint16_t    ZigPixelCount = 1;

--- a/src/output/OutputTM1814.cpp
+++ b/src/output/OutputTM1814.cpp
@@ -20,6 +20,9 @@
 #include "../ESPixelStick.h"
 #include "OutputTM1814.hpp"
 
+#define TM1814_COMMAND_DATA_VALUE               63 // 0x3f ~3F = C1 = 193
+static uint8_t PreambleData[8] = { 63, 63, 63, 63, 193, 193, 193, 193 };
+
 //----------------------------------------------------------------------------
 c_OutputTM1814::c_OutputTM1814 (c_OutputMgr::e_OutputChannelIds OutputChannelId,
     gpio_num_t outputGpio,
@@ -41,6 +44,18 @@ c_OutputTM1814::~c_OutputTM1814 ()
 
     // DEBUG_END;
 } // ~c_OutputTM1814
+
+//----------------------------------------------------------------------------
+void c_OutputTM1814::Begin ()
+{
+    // DEBUG_START;
+    
+    // c_OutputPixel::Begin ();
+
+    SetPreambleInformation (PreambleData, sizeof (PreambleData));
+
+    // DEBUG_END;
+} // GetConfig
 
 //----------------------------------------------------------------------------
 void c_OutputTM1814::GetConfig (ArduinoJson::JsonObject& jsonConfig)
@@ -68,7 +83,7 @@ void c_OutputTM1814::SetOutputBufferSize (uint16_t NumChannelsAvailable)
     c_OutputPixel::SetOutputBufferSize (NumChannelsAvailable);
 
     // Calculate our refresh time
-    FrameMinDurationInMicroSec = (TM1814_MICRO_SEC_PER_INTENSITY * OutputBufferSize) + InterFrameGapInMicroSec;
+    FrameMinDurationInMicroSec = (TM1814_MICRO_SEC_PER_INTENSITY * OutputBufferSize) + InterFrameGapInMicroSec + TM1814_COMMAND_DATA_TIME_US;
 
     // DEBUG_END;
 

--- a/src/output/OutputTM1814.hpp
+++ b/src/output/OutputTM1814.hpp
@@ -39,12 +39,15 @@ public:
     virtual ~c_OutputTM1814 ();
 
     // functions to be provided by the derived class
+    virtual void         Begin ();
     virtual bool         SetConfig (ArduinoJson::JsonObject & jsonConfig); ///< Set a new config in the driver
     virtual void         GetConfig (ArduinoJson::JsonObject & jsonConfig); ///< Get the current config used by the driver
             void         GetDriverName (String & sDriverName) { sDriverName = String (F ("TM1814")); }
     c_OutputMgr::e_OutputType GetOutputType () {return c_OutputMgr::e_OutputType::OutputType_TM1814;} ///< Have the instance report its type.
     virtual void         GetStatus (ArduinoJson::JsonObject& jsonStatus);
     virtual void         SetOutputBufferSize (uint16_t NumChannelsAvailable);
+
+protected:
 
 #define TM1814_PIXEL_NS_BIT_TOTAL          1250.0
 #define TM1814_PIXEL_NS_BIT_0_LOW           360.0 // 360ns +/- 50ns per datasheet
@@ -56,6 +59,9 @@ public:
 #define TM1814_MICRO_SEC_PER_INTENSITY          10L     // ((1/800000) * 8 bits) = 10us
 #define TM1814_MIN_IDLE_TIME_US                 (TM1814_PIXEL_NS_IDLE / 1000.0)
 #define TM1814_DEFAULT_INTENSITY_PER_PIXEL      3
+#define TM1814_COMMAND_DATA_TIME_US             (8 * TM1814_MICRO_SEC_PER_INTENSITY)
+
+private:
 
 }; // c_OutputTM1814
 

--- a/src/output/OutputTM1814Rmt.cpp
+++ b/src/output/OutputTM1814Rmt.cpp
@@ -120,7 +120,9 @@ static void IRAM_ATTR rmt_intr_handler (void* param)
 void c_OutputTM1814Rmt::Begin ()
 {
     // DEBUG_START;
-    // RmtChannelId = 0;
+
+    c_OutputTM1814::Begin ();
+
     // DEBUG_V (String ("DataPin: ") + String (DataPin));
     // DEBUG_V (String (" RmtChannelId: ") + String (RmtChannelId));
 

--- a/src/output/OutputTM1814Uart.cpp
+++ b/src/output/OutputTM1814Uart.cpp
@@ -257,6 +257,28 @@ void c_OutputTM1814Uart::Render ()
     // get the next frame started
     StartNewFrame ();
 
+    // Write the command bytes
+    register uint8_t Command    = 63;
+    register uint32_t OneValue  = Convert2BitIntensityToUartDataStream[1];
+    register uint32_t ZeroValue = Convert2BitIntensityToUartDataStream[0];
+
+    for (uint8_t NumCommands = 4; NumCommands > 0; --NumCommands)
+    {
+        for (uint8_t bitmask = 0x80; 0 != bitmask; bitmask >>= 1)
+        {
+            enqueue ((Command & bitmask) ? OneValue : ZeroValue);
+        }
+    }
+
+    // Send it again but invert it
+    for (uint8_t NumCommands = 4; NumCommands > 0; --NumCommands)
+    {
+        for (uint8_t bitmask = 0x80; 0 != bitmask; bitmask >>= 1)
+        {
+            enqueue ((Command & bitmask) ? ZeroValue : OneValue);
+        }
+    }
+
     // enable interrupts
     WRITE_PERI_REG (UART_CONF1 (UartId), PIXEL_FIFO_TRIGGER_LEVEL << UART_TXFIFO_EMPTY_THRHD_S);
     SET_PERI_REG_MASK (UART_INT_ENA (UartId), UART_TXFIFO_EMPTY_INT_ENA);

--- a/src/output/OutputTM1814Uart.cpp
+++ b/src/output/OutputTM1814Uart.cpp
@@ -138,7 +138,7 @@ void c_OutputTM1814Uart::Begin ()
     InitializeUart (uart_config, PIXEL_FIFO_TRIGGER_LEVEL);
 #endif
 
-    DEBUG_V (String ("TM1814_BAUD_RATE: ") + String (TM1814_BAUD_RATE));
+    // DEBUG_V (String ("TM1814_BAUD_RATE: ") + String (TM1814_BAUD_RATE));
 
     // Atttach interrupt handler
 #ifdef ARDUINO_ARCH_ESP8266

--- a/src/output/OutputWS2801.cpp
+++ b/src/output/OutputWS2801.cpp
@@ -16,6 +16,7 @@
 *  or use of these programs.
 *
 */
+#ifdef USE_WS2801
 
 #include "../ESPixelStick.h"
 #include "OutputWS2801.hpp"
@@ -96,3 +97,5 @@ bool c_OutputWS2801::SetConfig (ArduinoJson::JsonObject& jsonConfig)
     return response;
 
 } // SetConfig
+
+#endif // def USE_WS2801

--- a/src/output/OutputWS2801.cpp
+++ b/src/output/OutputWS2801.cpp
@@ -1,0 +1,98 @@
+/*
+* OutputWS2801.cpp - WS2801 driver code for ESPixelStick UART
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2015 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*/
+
+#include "../ESPixelStick.h"
+#include "OutputWS2801.hpp"
+
+//----------------------------------------------------------------------------
+c_OutputWS2801::c_OutputWS2801 (c_OutputMgr::e_OutputChannelIds OutputChannelId,
+    gpio_num_t outputGpio,
+    uart_port_t uart,
+    c_OutputMgr::e_OutputType outputType) :
+    c_OutputPixel (OutputChannelId, outputGpio, uart, outputType)
+{
+    // DEBUG_START;
+
+    InterFrameGapInMicroSec = WS2801_MIN_IDLE_TIME_US;
+
+    // DEBUG_END;
+} // c_OutputWS2801
+
+//----------------------------------------------------------------------------
+c_OutputWS2801::~c_OutputWS2801 ()
+{
+    // DEBUG_START;
+
+    // DEBUG_END;
+} // ~c_OutputWS2801
+
+//----------------------------------------------------------------------------
+void c_OutputWS2801::GetConfig (ArduinoJson::JsonObject& jsonConfig)
+{
+    // DEBUG_START;
+
+    c_OutputPixel::GetConfig (jsonConfig);
+
+    // DEBUG_END;
+} // GetConfig
+
+//----------------------------------------------------------------------------
+void c_OutputWS2801::GetStatus (ArduinoJson::JsonObject& jsonStatus)
+{
+    c_OutputPixel::GetStatus (jsonStatus);
+
+} // GetStatus
+
+//----------------------------------------------------------------------------
+void c_OutputWS2801::SetOutputBufferSize (uint16_t NumChannelsAvailable)
+{
+    // DEBUG_START;
+
+        // Stop current output operation
+    c_OutputPixel::SetOutputBufferSize (NumChannelsAvailable);
+
+    // Calculate our refresh time
+    FrameMinDurationInMicroSec = (WS2801_MICRO_SEC_PER_INTENSITY * OutputBufferSize) + InterFrameGapInMicroSec;
+
+    // DEBUG_END;
+
+} // SetBufferSize
+
+//----------------------------------------------------------------------------
+/* Process the config
+*
+*   needs
+*       reference to string to process
+*   returns
+*       true - config has been accepted
+*       false - Config rejected. Using defaults for invalid settings
+*/
+bool c_OutputWS2801::SetConfig (ArduinoJson::JsonObject& jsonConfig)
+{
+    // DEBUG_START;
+
+    bool response = c_OutputPixel::SetConfig (jsonConfig);
+
+    // Calculate our refresh time
+    FrameMinDurationInMicroSec = (WS2801_MICRO_SEC_PER_INTENSITY * numIntensityBytesPerPixel * OutputBufferSize) + InterFrameGapInMicroSec;
+
+    // DEBUG_END;
+    return response;
+
+} // SetConfig

--- a/src/output/OutputWS2801.hpp
+++ b/src/output/OutputWS2801.hpp
@@ -21,7 +21,7 @@
 *   interface.
 *
 */
-
+#ifdef USE_WS2801
 #include "OutputPixel.hpp"
 
 class c_OutputWS2801 : public c_OutputPixel
@@ -55,4 +55,5 @@ protected:
 // #define WS2801_DEFAULT_INTENSITY_PER_PIXEL      3
 
 }; // c_OutputWS2801
+#endif // def USE_WS2801
 

--- a/src/output/OutputWS2801.hpp
+++ b/src/output/OutputWS2801.hpp
@@ -1,0 +1,58 @@
+#pragma once
+/*
+* OutputWS2801.h - WS2801 driver code for ESPixelStick
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2015 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*   This is a derived class that converts data in the output buffer into
+*   pixel intensities and then transmits them through the configured serial
+*   interface.
+*
+*/
+
+#include "OutputPixel.hpp"
+
+class c_OutputWS2801 : public c_OutputPixel
+{
+public:
+    // These functions are inherited from c_OutputCommon
+    c_OutputWS2801 (c_OutputMgr::e_OutputChannelIds OutputChannelId,
+                      gpio_num_t outputGpio,
+                      uart_port_t uart,
+                      c_OutputMgr::e_OutputType outputType);
+    virtual ~c_OutputWS2801 ();
+
+    // functions to be provided by the derived class
+    virtual bool         SetConfig (ArduinoJson::JsonObject & jsonConfig); ///< Set a new config in the driver
+    virtual void         GetConfig (ArduinoJson::JsonObject & jsonConfig); ///< Get the current config used by the driver
+            void         GetDriverName (String & sDriverName) { sDriverName = String (F ("WS2801")); }
+    c_OutputMgr::e_OutputType GetOutputType () {return c_OutputMgr::e_OutputType::OutputType_WS2801;} ///< Have the instance report its type.
+    virtual void         GetStatus (ArduinoJson::JsonObject& jsonStatus);
+    virtual void         SetOutputBufferSize (uint16_t NumChannelsAvailable);
+
+protected:
+
+#define WS2801_PIXEL_NS_BIT_0_HIGH          350.0 // 350ns +/- 150ns per datasheet
+#define WS2801_PIXEL_NS_BIT_0_LOW           900.0 // 900ns +/- 150ns per datasheet
+#define WS2801_PIXEL_NS_BIT_1_HIGH          900.0 // 900ns +/- 150ns per datasheet
+#define WS2801_PIXEL_NS_BIT_1_LOW           350.0 // 350ns +/- 150ns per datasheet
+#define WS2801_PIXEL_NS_IDLE             300000.0 // 300us per datasheet
+
+#define WS2801_MICRO_SEC_PER_INTENSITY          10L     // ((1/800000) * 8 bits) = 10us
+#define WS2801_MIN_IDLE_TIME_US                 (WS2801_PIXEL_NS_IDLE / 1000.0)
+// #define WS2801_DEFAULT_INTENSITY_PER_PIXEL      3
+
+}; // c_OutputWS2801
+

--- a/src/output/OutputWS2801Spi.cpp
+++ b/src/output/OutputWS2801Spi.cpp
@@ -1,0 +1,193 @@
+/*
+* OutputWS2801Spi.cpp - WS2801 driver code for ESPixelStick SPI Channel
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2015 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*/
+#ifdef ARDUINO_ARCH_ESP32
+
+#include "../ESPixelStick.h"
+#include "OutputWS2801Spi.hpp"
+
+
+// forward declaration for the isr handler
+static void IRAM_ATTR SPI_intr_handler (void* param);
+
+//----------------------------------------------------------------------------
+c_OutputWS2801Spi::c_OutputWS2801Spi (c_OutputMgr::e_OutputChannelIds OutputChannelId,
+    gpio_num_t outputGpio,
+    uart_port_t uart,
+    c_OutputMgr::e_OutputType outputType) :
+    c_OutputWS2801 (OutputChannelId, outputGpio, uart, outputType)
+{
+    // DEBUG_START;
+
+
+    // DEBUG_END;
+} // c_OutputWS2801Spi
+
+//----------------------------------------------------------------------------
+c_OutputWS2801Spi::~c_OutputWS2801Spi ()
+{
+    // DEBUG_START;
+    if (gpio_num_t (-1) == DataPin) { return; }
+
+    // Disable all interrupts for this SPI Channel.
+    // DEBUG_V ("");
+
+    // Clear all pending interrupts in the SPI Channel
+    // DEBUG_V ("");
+    
+    // spicommon_dma_chan_free (int dma_chan);
+    // spicommon_periph_free (spi_host_device_thost);
+    // spicommon_bus_free_io (spi_host_device_thost);
+    // esp_intr_free (SPI_intr_handle);
+
+    // make sure no existing low level driver is running
+    // DEBUG_V ("");
+
+    // DEBUG_V (String("SPIChannelId: ") + String(SPIChannelId));
+    // SPIEnd (SPIObject);
+    // DEBUG_END;
+} // ~c_OutputWS2801Spi
+
+//----------------------------------------------------------------------------
+/* shell function to set the 'this' pointer of the real ISR
+   This allows me to use non static variables in the ISR.
+ */
+static void IRAM_ATTR SPI_intr_handler (void* param)
+{
+    reinterpret_cast <c_OutputWS2801Spi*>(param)->ISR_Handler ();
+} // SPI_intr_handler
+
+//----------------------------------------------------------------------------
+/* Use the current config to set up the output port
+*/
+void c_OutputWS2801Spi::Begin ()
+{
+    // DEBUG_START;
+    // SPIChannelId = 0;
+    // DEBUG_V (String ("DataPin: ") + String (DataPin));
+    // DEBUG_V (String (" SPIChannelId: ") + String (SPIChannelId));
+
+    // int dmach = 1;
+    esp_err_t ret;
+    spi_device_handle_t spi = nullptr;
+
+    spi_bus_config_t buscfg;
+    memset ((void*)&buscfg, 0x00, sizeof (buscfg));
+    buscfg.miso_io_num = -1;
+    buscfg.mosi_io_num = DataPin;
+    buscfg.sclk_io_num = 15;
+    buscfg.quadwp_io_num = -1;
+    buscfg.quadhd_io_num = -1;
+    buscfg.max_transfer_sz = OM_MAX_NUM_CHANNELS;
+    buscfg.flags = SPICOMMON_BUSFLAG_MASTER;
+
+    spi_device_interface_config_t devcfg;
+    memset ((void*)&devcfg, 0x00, sizeof (devcfg));
+    // devcfg.command_bits = 0; // No command to send
+    // devcfg.address_bits = 0; // No bus address to send
+    // devcfg.dummy_bits = 0; // No dummy bits to send
+    // devcfg.duty_cycle_pos = 0; // 50% Duty cycle
+    devcfg.clock_speed_hz = SPI_MASTER_FREQ_1M;     //Initial clock out at 5 MHz
+    // devcfg.mode = 0;                                //SPI mode 0
+    devcfg.spics_io_num = -1;                       //we will NOT use CS pin
+    devcfg.queue_size = 2;                          //We want to be able to queue 7 transactions at a time
+    // devcfg.pre_cb = nullptr;                        //Specify pre-transfer callback to handle D/C line
+    // devcfg.post_cb = ws2801_transfer_callback;      //Specify post-transfer callback to handle D/C line
+    // devcfg.flags = 0;
+
+    // spi_bus_initialize (spi_host_device_thost, constspi_bus_config_t * bus_config, int dma_chan);
+
+    // spicommon_dma_chan_claim (int dma_chan)
+    // spicommon_periph_claim (spi_host_device_thost);
+    // spicommon_bus_initialize_io (spi_host_device_thost, constspi_bus_config_t * bus_config, int dma_chan, int flags, bool* is_native);
+    // ESP_ERROR_CHECK (esp_intr_alloc (ETS_SPI_INTR_SOURCE, ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_LEVEL3 | ESP_INTR_FLAG_SHARED, SPI_intr_handler, this, &SPI_intr_handle));
+
+    // spicommon_setup_dma_desc_links (lldesc_t * dmadesc, int len, const uint8_t * data, bool isrx);
+
+    // Start output
+    // DEBUG_END;
+
+} // init
+
+//----------------------------------------------------------------------------
+bool c_OutputWS2801Spi::SetConfig (ArduinoJson::JsonObject& jsonConfig)
+{
+    // DEBUG_START;
+
+    bool response = c_OutputWS2801::SetConfig (jsonConfig);
+
+    //     SPI_set_pin (SPIChannelId, SPI_mode_t::SPI_MODE_TX, DataPin);
+
+    // DEBUG_END;
+    return response;
+
+} // GetStatus
+
+//----------------------------------------------------------------------------
+void IRAM_ATTR c_OutputWS2801Spi::ISR_Handler ()
+{
+
+} // ISR_Handler
+
+//----------------------------------------------------------------------------
+void IRAM_ATTR c_OutputWS2801Spi::ISR_Handler_StartNewFrame ()
+{
+    FrameStartCounter++;
+
+
+
+    StartNewFrame ();
+    ISR_Handler_SendIntensityData ();
+
+} // ISR_Handler_StartNewFrame
+
+//----------------------------------------------------------------------------
+/*
+ * Fill the MEMBLK with a fixed number of intensity values.
+ */
+void IRAM_ATTR c_OutputWS2801Spi::ISR_Handler_SendIntensityData ()
+{
+    uint32_t NumEmptyIntensitySlots = NumIntensityValuesPerInterrupt;
+
+    while ((NumEmptyIntensitySlots--) && (MoreDataToSend))
+    {
+        uint8_t IntensityValue = GetNextIntensityToSend ();
+
+        // convert the intensity data into SPI data
+        for (uint8_t bitmask = 0x80; 0 != bitmask; bitmask >>= 1)
+        {
+        }
+    } // end while there is space in the buffer
+
+    // terminate the current data in the buffer
+
+} // ISR_Handler_SendIntensityData
+
+//----------------------------------------------------------------------------
+void c_OutputWS2801Spi::Render ()
+{
+    // DEBUG_START;
+
+    ISR_Handler_StartNewFrame ();
+    ReportNewFrame ();
+
+    // DEBUG_END;
+
+} // render
+
+#endif // def ARDUINO_ARCH_ESP32

--- a/src/output/OutputWS2801Spi.cpp
+++ b/src/output/OutputWS2801Spi.cpp
@@ -16,7 +16,7 @@
 *  or use of these programs.
 *
 */
-#ifdef ARDUINO_ARCH_ESP32
+#ifdef USE_WS2801
 
 #include "../ESPixelStick.h"
 #include "OutputWS2801Spi.hpp"
@@ -190,4 +190,4 @@ void c_OutputWS2801Spi::Render ()
 
 } // render
 
-#endif // def ARDUINO_ARCH_ESP32
+#endif // def USE_WS2801

--- a/src/output/OutputWS2801Spi.hpp
+++ b/src/output/OutputWS2801Spi.hpp
@@ -1,0 +1,65 @@
+#pragma once
+/*
+* OutputWS2801Spi.h - WS2801 driver code for ESPixelStick Spi Channel
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2015 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*   This is a derived class that converts data in the output buffer into
+*   pixel intensities and then transmits them through the configured serial
+*   interface.
+*
+*/
+#ifdef ARDUINO_ARCH_ESP32
+
+#include "OutputWS2801.hpp"
+
+#include <driver/spi_master.h>
+
+class c_OutputWS2801Spi : public c_OutputWS2801
+{
+public:
+    // These functions are inherited from c_OutputCommon
+    c_OutputWS2801Spi (c_OutputMgr::e_OutputChannelIds OutputChannelId,
+                      gpio_num_t outputGpio,
+                      uart_port_t uart,
+                      c_OutputMgr::e_OutputType outputType);
+    virtual ~c_OutputWS2801Spi ();
+
+    // functions to be provided by the derived class
+    void    Begin ();                                         ///< set up the operating environment based on the current config (or defaults)
+    bool    SetConfig (ArduinoJson::JsonObject& jsonConfig);  ///< Set a new config in the driver
+    void    Render ();                                        ///< Call from loop(),  renders output data
+    void    PauseOutput () {};
+
+    /// Interrupt Handler
+    void IRAM_ATTR ISR_Handler (); ///< ISR
+    void IRAM_ATTR ISR_Handler_SendIntensityData (); ///< ISR
+    void IRAM_ATTR ISR_Handler_StartNewFrame (); ///< ISR
+
+private:
+
+#define SPI_MASTER_FREQ_1M      (APB_CLK_FREQ/80) // 1Mhz
+
+    uint8_t NumIntensityValuesPerInterrupt = 0;
+    uint8_t NumIntensityBitsPerInterrupt = 0;
+
+    uint32_t FrameStartCounter = 0;
+    // uint32_t DataISRcounter = 0;
+    // uint32_t FrameDoneCounter = 0;
+    // uint32_t FrameEndISRcounter = 0;
+
+}; // c_OutputWS2801Spi
+
+#endif // def ARDUINO_ARCH_ESP32

--- a/src/output/OutputWS2801Spi.hpp
+++ b/src/output/OutputWS2801Spi.hpp
@@ -21,7 +21,7 @@
 *   interface.
 *
 */
-#ifdef ARDUINO_ARCH_ESP32
+#ifdef USE_WS2801
 
 #include "OutputWS2801.hpp"
 
@@ -62,4 +62,4 @@ private:
 
 }; // c_OutputWS2801Spi
 
-#endif // def ARDUINO_ARCH_ESP32
+#endif // def USE_WS2801


### PR DESCRIPTION
Moved TM1814 command preamble processing to use a more general pixel preamble process that can send any number of bytes before sending intensity data and can be used by any future pixel implementations.