### PR TITLE
Document alternate port for development

### DIFF
--- a/html/README.md
+++ b/html/README.md
@@ -21,7 +21,7 @@ These are the web source files which must be placed in ```data/www``` and upload
 
 ## Development
 
-When developing, check the comments at the top and bottom of ```index.html``` to use local sources. You'll need to use a local web server due to the ajax page loading. Python includes a simple one, just run ```python -m http.server``` (python 3) in this directory and connect to ```http://localhost:8000/?target=x.x.x.x```  where ```x.x.x.x``` is a device with the ESPixelStick firmware to use for the websocket connection.
+When developing, check the comments at the top and bottom of ```index.html``` to use local sources. You'll need to use a local web server due to the ajax page loading. Python includes a simple one, just run ```python -m http.server 8888``` (python 3) in this directory and connect to ```http://localhost:8888/?target=x.x.x.x```  where ```x.x.x.x``` is a device with the ESPixelStick firmware to use for the websocket connection.
 
 ## 3rd Party Software
 


### PR DESCRIPTION
Turns out that Windows prevents the use of port `8000`.  To see the list of Windows' restricted ports:

```
C:\users> netsh interface ipv4 show excludedportrange protocol=tcp
Protocol tcp Port Exclusion Ranges
Start Port    End Port
----------    --------
      1035        1134
      1135        1234
...
      7781        7880
      7981        8080
      8081        8180
```

Otherwise, you will get an error similar to:

```
OSError: [WinError 10013] An attempt was made to access a socket in a way forbidden by its access permissions
```