### PR TITLE
Adds Relay PWM support

### DIFF
--- a/ESPixelStick/src/ConstNames.cpp
+++ b/ESPixelStick/src/ConstNames.cpp
@@ -128,6 +128,7 @@ const char CN_plussigns                [] = "+++++";
 const char CN_polarity                 [] = "polarity";
 const char CN_port                     [] = "port";
 const char CN_prependnullcount         [] = "prependnullcount";
+const char CN_pwm                      [] = "pwm";
 const char CN_r                        [] = "r";
 const char CN_remote                   [] = "remote";
 const char CN_rev                      [] = "rev";

--- a/ESPixelStick/src/ConstNames.hpp
+++ b/ESPixelStick/src/ConstNames.hpp
@@ -130,6 +130,7 @@ extern const char CN_playFseq[];
 extern const char CN_playlist [];
 extern const char CN_plussigns [];
 extern const char CN_prependnullcount [];
+extern const char CN_pwm [];
 extern const char CN_remote [];
 extern const char CN_r[];
 extern const char CN_rev[];

--- a/ESPixelStick/src/output/OutputRelay.hpp
+++ b/ESPixelStick/src/output/OutputRelay.hpp
@@ -37,6 +37,7 @@ public:
     {
         bool        Enabled;
         bool        InvertOutput;
+        bool        Pwm;
         uint8_t     OnOffTriggerLevel;
         gpio_num_t  GpioId;
         uint8_t     OnValue;
@@ -66,6 +67,7 @@ private:
 #   define OM_RELAY_UPDATE_INTERVAL_NAME    CN_updateinterval
 #   define OM_RELAY_CHANNEL_ENABLED_NAME    CN_en
 #   define OM_RELAY_CHANNEL_INVERT_NAME     CN_inv
+#   define OM_RELAY_CHANNEL_PWM_NAME        CN_pwm
 
     bool    validate ();
 

--- a/html/relay.html
+++ b/html/relay.html
@@ -13,6 +13,7 @@
                     <th id="chanId_hr">Channel</th>
                     <th id="Enabled_hr">Enabled</th>
                     <th id="Inverted_hr">Inverted</th>
+                    <th id="Pwm_hr">Pwm</th>
                     <th id="gpioId_hr">GPIO ID</th>
                     <th id="threshhold_hr">Trigger Threshold</th>
                 </tr>

--- a/html/script.js
+++ b/html/script.js
@@ -495,15 +495,17 @@ function ProcessModeConfigurationDataRelay(RelayConfig)
         let ChanIdPattern     = '<td id="chanId_'                            + (CurrentRowId) + '">a</td>';
         let EnabledPattern    = '<td><input type="checkbox" id="Enabled_'    + (CurrentRowId) + '"></td>';
         let InvertedPattern   = '<td><input type="checkbox" id="Inverted_'   + (CurrentRowId) + '"></td>';
+        let PwmPattern        = '<td><input type="checkbox" id="Pwm_'        + (CurrentRowId) + '"></td>';
         let gpioPattern       = '<td><input type="number"   id="gpioId_'     + (CurrentRowId) + '"step="1" min="0" max="24"  value="30"  class="form-control is-valid"></td>';
         let threshholdPattern = '<td><input type="number"   id="threshhold_' + (CurrentRowId) + '"step="1" min="0" max="255" value="300" class="form-control is-valid"></td>';
 
-        let rowPattern = '<tr>' + ChanIdPattern + EnabledPattern + InvertedPattern + gpioPattern + threshholdPattern + '</tr>';
+        let rowPattern = '<tr>' + ChanIdPattern + EnabledPattern + InvertedPattern + PwmPattern + gpioPattern + threshholdPattern + '</tr>';
         $('#relaychannelconfigurationtable tr:last').after(rowPattern);
 
         $('#chanId_'     + CurrentRowId).attr('style', $('#chanId_hr').attr('style'));
         $('#Enabled_'    + CurrentRowId).attr('style', $('#Enabled_hr').attr('style'));
         $('#Inverted_'   + CurrentRowId).attr('style', $('#Inverted_hr').attr('style'));
+        $('#Pwm_'        + CurrentRowId).attr('style', $('#Pwm_hr').attr('style'));
         $('#gpioId_'     + CurrentRowId).attr('style', $('#gpioId_hr').attr('style'));
         $('#threshhold_' + CurrentRowId).attr('style', $('#threshhold_hr').attr('style'));
     }
@@ -515,6 +517,7 @@ function ProcessModeConfigurationDataRelay(RelayConfig)
         $('#chanId_'     + (currentChannelRowId)).html(currentChannelRowId);
         $('#Enabled_'    + (currentChannelRowId)).prop("checked", CurrentChannelConfig.en);
         $('#Inverted_'   + (currentChannelRowId)).prop("checked", CurrentChannelConfig.inv);
+        $('#Pwm_'        + (currentChannelRowId)).prop("checked", CurrentChannelConfig.pwm);
         $('#gpioId_'     + (currentChannelRowId)).val(CurrentChannelConfig.gid);
         $('#threshhold_' + (currentChannelRowId)).val(CurrentChannelConfig.trig);
     });
@@ -916,6 +919,7 @@ function ExtractChannelConfigFromHtmlPage(JsonConfig, SectionName)
                 let currentChannelRowId = CurrentChannelConfig.id + 1;
                 CurrentChannelConfig.en   = $('#Enabled_' + (currentChannelRowId)).prop("checked");
                 CurrentChannelConfig.inv  = $('#Inverted_' + (currentChannelRowId)).prop("checked");
+                CurrentChannelConfig.pwm  = $('#Pwm_' + (currentChannelRowId)).prop("checked");
                 CurrentChannelConfig.gid  = parseInt($('#gpioId_' + (currentChannelRowId)).val(), 10);
                 CurrentChannelConfig.trig = parseInt($('#threshhold_' + (currentChannelRowId)).val(), 10);
             });


### PR DESCRIPTION
there is a checkbox added to the relay configuration allowing the selection of a
pwm support.  If pwm support enabled then the code will perform an
analogwrite to the GPIO pin instead of a digitalwrite.