### PR TITLE
Converted FPP File Player to use the elapsed time field instead of the frameid filed in the sync status message. This allows us to have a different frame rate than the master.

### DIFF
--- a/ESPixelStick/src/input/InputFPPRemotePlayEffect.cpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayEffect.cpp
@@ -52,7 +52,7 @@ c_InputFPPRemotePlayEffect::~c_InputFPPRemotePlayEffect ()
 } // ~c_InputFPPRemotePlayEffect
 
 //-----------------------------------------------------------------------------
-void c_InputFPPRemotePlayEffect::Start (String & FileName, uint32_t duration, uint32_t )
+void c_InputFPPRemotePlayEffect::Start (String & FileName, float duration, uint32_t )
 {
     // DEBUG_START;
 
@@ -72,11 +72,11 @@ void c_InputFPPRemotePlayEffect::Stop ()
 } // Stop
 
 //-----------------------------------------------------------------------------
-void c_InputFPPRemotePlayEffect::Sync (String& FileName, uint32_t FrameId)
+void c_InputFPPRemotePlayEffect::Sync (String& FileName, float SecondsElapsed)
 {
     // DEBUG_START;
 
-    pCurrentFsmState->Sync (FrameId);
+    pCurrentFsmState->Sync (SecondsElapsed);
 
     // DEBUG_END;
 } // Sync

--- a/ESPixelStick/src/input/InputFPPRemotePlayEffect.hpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayEffect.hpp
@@ -30,9 +30,9 @@ public:
     c_InputFPPRemotePlayEffect (c_InputMgr::e_InputChannelIds InputChannelId);
     ~c_InputFPPRemotePlayEffect ();
 
-    virtual void Start (String & FileName, uint32_t duration, uint32_t PlayCount);
+    virtual void Start (String & FileName, float duration, uint32_t PlayCount);
     virtual void Stop  ();
-    virtual void Sync  (String & FileName, uint32_t FrameId);
+    virtual void Sync  (String & FileName, float SecondsElapsed);
     virtual void Poll  (uint8_t * Buffer, size_t BufferSize);
     virtual void GetStatus (JsonObject & jsonStatus);
     virtual bool IsIdle () { return (pCurrentFsmState == &fsm_PlayEffect_state_Idle_imp); }

--- a/ESPixelStick/src/input/InputFPPRemotePlayEffectFsm.cpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayEffectFsm.cpp
@@ -45,7 +45,7 @@ void fsm_PlayEffect_state_Idle::Init (c_InputFPPRemotePlayEffect* Parent)
 } // fsm_PlayEffect_state_Idle::Init
 
 //-----------------------------------------------------------------------------
-void fsm_PlayEffect_state_Idle::Start (String & ConfigString, uint32_t )
+void fsm_PlayEffect_state_Idle::Start (String & ConfigString, float )
 {
     // DEBUG_START;
 
@@ -90,7 +90,7 @@ void fsm_PlayEffect_state_Idle::Stop (void)
 } // fsm_PlayEffect_state_Idle::Stop
 
 //-----------------------------------------------------------------------------
-bool fsm_PlayEffect_state_Idle::Sync (uint32_t FrameId)
+bool fsm_PlayEffect_state_Idle::Sync (float)
 {
     // DEBUG_START;
 
@@ -148,7 +148,7 @@ void fsm_PlayEffect_state_PlayingEffect::Init (c_InputFPPRemotePlayEffect* Paren
 } // fsm_PlayEffect_state_PlayingEffect::Init
 
 //-----------------------------------------------------------------------------
-void fsm_PlayEffect_state_PlayingEffect::Start (String & FileName, uint32_t FrameId)
+void fsm_PlayEffect_state_PlayingEffect::Start (String &, float)
 {
     // DEBUG_START;
 
@@ -174,7 +174,7 @@ void fsm_PlayEffect_state_PlayingEffect::Stop (void)
 } // fsm_PlayEffect_state_PlayingEffect::Stop
 
 //-----------------------------------------------------------------------------
-bool fsm_PlayEffect_state_PlayingEffect::Sync (uint32_t FrameId)
+bool fsm_PlayEffect_state_PlayingEffect::Sync (float)
 {
     // DEBUG_START;
 
@@ -210,4 +210,3 @@ void fsm_PlayEffect_state_PlayingEffect::GetStatus (JsonObject& jsonStatus)
     // DEBUG_END;
 
 } // fsm_PlayEffect_state_PlayingEffect::GetStatus
-

--- a/ESPixelStick/src/input/InputFPPRemotePlayEffectFsm.hpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayEffectFsm.hpp
@@ -35,9 +35,9 @@ public:
     virtual void Poll (uint8_t * Buffer, size_t BufferSize) = 0;
     virtual void Init (c_InputFPPRemotePlayEffect * Parent) = 0;
     virtual void GetStateName (String & sName) = 0;
-    virtual void Start (String & FileName, uint32_t FrameId) = 0;
+    virtual void Start (String & FileName, float SecondsElapsed) = 0;
     virtual void Stop (void) = 0;
-    virtual bool Sync (uint32_t FrameId) = 0;
+    virtual bool Sync (float SecondsElapsed) = 0;
     virtual void GetStatus (JsonObject& jsonStatus) = 0;
     void GetDriverName (String& Name) { Name = "InputMgr"; }
 
@@ -53,9 +53,9 @@ public:
     virtual void Poll (uint8_t * Buffer, size_t BufferSize);
     virtual void Init (c_InputFPPRemotePlayEffect* Parent);
     virtual void GetStateName (String & sName) { sName = CN_Idle; }
-    virtual void Start (String & FileName, uint32_t FrameId);
+    virtual void Start (String & FileName, float SecondsElapsed);
     virtual void Stop (void);
-    virtual bool Sync (uint32_t FrameId);
+    virtual bool Sync (float SecondsElapsed);
     virtual void GetStatus (JsonObject& jsonStatus);
 
 }; // fsm_PlayEffect_state_Idle
@@ -67,9 +67,9 @@ public:
     virtual void Poll (uint8_t * Buffer, size_t BufferSize);
     virtual void Init (c_InputFPPRemotePlayEffect* Parent);
     virtual void GetStateName (String & sName) { sName = CN_Effect; }
-    virtual void Start (String & FileName, uint32_t FrameId);
+    virtual void Start (String & FileName, float SecondsElapsed);
     virtual void Stop (void);
-    virtual bool Sync (uint32_t FrameId);
+    virtual bool Sync (float SecondsElapsed);
     virtual void GetStatus (JsonObject& jsonStatus);
 
 }; // fsm_PlayEffect_state_PlayingEffect

--- a/ESPixelStick/src/input/InputFPPRemotePlayFile.hpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayFile.hpp
@@ -31,16 +31,14 @@ public:
     c_InputFPPRemotePlayFile (c_InputMgr::e_InputChannelIds InputChannelId);
     ~c_InputFPPRemotePlayFile ();
 
-    virtual void Start (String & FileName, uint32_t FrameId, uint32_t RemainingPlayCount);
+    virtual void Start (String & FileName, float SecondsElapsed, uint32_t RemainingPlayCount);
     virtual void Stop ();
-    virtual void Sync (String& FileName, uint32_t FrameId);
+    virtual void Sync (String& FileName, float SecondsElapsed);
     virtual void Poll (uint8_t* Buffer, size_t BufferSize);
     virtual void GetStatus (JsonObject & jsonStatus);
     virtual bool IsIdle () { return (pCurrentFsmState == &fsm_PlayFile_state_Idle_imp); }
     
     void TimerPoll ();
-
-    uint32_t GetLastFrameId ()  { return FrameControl.LastPlayedFrameId; }
 
 private:
 #define ELAPSED_PLAY_TIMER_INTERVAL_MS  10
@@ -70,15 +68,13 @@ private:
         uint32_t          TotalNumberOfFramesInSequence = 0;
         uint32_t          ElapsedPlayTimeMS = 0;
 
-        uint32_t          StartingFrameId = 0;
-        uint32_t          LastPlayedFrameId = 0;
     } FrameControl;
 
     struct SyncControl_t
     {
         uint32_t          SyncCount = 0;
         uint32_t          SyncAdjustmentCount = 0;
-        uint32_t          LastRcvdSyncFrameId = 0;
+        float             LastRcvdElapsedSeconds = 0.0;
     } SyncControl;
 
     uint8_t * Buffer = nullptr;
@@ -94,8 +90,7 @@ private:
 #define MAX_NUM_SPARSE_RANGES 5
     FSEQParsedRangeEntry SparseRanges[MAX_NUM_SPARSE_RANGES];
 
-    uint32_t          CalculateFrameId (int32_t SyncOffsetMS = 0);
-    void              CalculatePlayStartTime (uint32_t FrameId);
+    uint32_t          CalculateFrameId (uint32_t ElapsedMS, int32_t SyncOffsetMS);
     bool              ParseFseqFile ();
 
     String            LastFailedPlayStatusMsg;

--- a/ESPixelStick/src/input/InputFPPRemotePlayFileFsm.hpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayFileFsm.hpp
@@ -36,9 +36,9 @@ public:
     virtual void Poll () = 0;
     virtual void Init (c_InputFPPRemotePlayFile * Parent) = 0;
     virtual void GetStateName (String & sName) = 0;
-    virtual void Start (String & FileName, uint32_t FrameId, uint32_t RemainingPlayCount) = 0;
+    virtual void Start (String & FileName, float SecondsElapsed, uint32_t RemainingPlayCount) = 0;
     virtual void Stop (void) = 0;
-    virtual bool Sync (String& FileName, uint32_t FrameId) = 0;
+    virtual bool Sync (String& FileName, float SecondsElapsed) = 0;
     void GetDriverName (String& Name) { Name = "InputMgr"; }
     virtual IRAM_ATTR void TimerPoll ();
 
@@ -54,9 +54,9 @@ public:
     virtual void Poll ();
     virtual void Init (c_InputFPPRemotePlayFile* Parent);
     virtual void GetStateName (String & sName) { sName = CN_Idle; }
-    virtual void Start (String & FileName, uint32_t FrameId, uint32_t RemainingPlayCount);
+    virtual void Start (String & FileName, float SecondsElapsed, uint32_t RemainingPlayCount);
     virtual void Stop (void);
-    virtual bool Sync (String& FileName, uint32_t FrameId);
+    virtual bool Sync (String& FileName, float SecondsElapsed);
     virtual IRAM_ATTR void TimerPoll ();
 
 }; // fsm_PlayFile_state_Idle
@@ -68,9 +68,9 @@ public:
     virtual void Poll ();
     virtual void Init (c_InputFPPRemotePlayFile* Parent);
     virtual void GetStateName (String& sName) { sName = F ("Starting"); }
-    virtual void Start (String& FileName, uint32_t FrameId, uint32_t RemainingPlayCount);
+    virtual void Start (String& FileName, float SecondsElapsed, uint32_t RemainingPlayCount);
     virtual void Stop (void);
-    virtual bool Sync (String& FileName, uint32_t FrameId);
+    virtual bool Sync (String& FileName, float SecondsElapsed);
     virtual IRAM_ATTR void TimerPoll ();
 
 }; // fsm_PlayFile_state_Starting
@@ -82,9 +82,9 @@ public:
     virtual void Poll ();
     virtual void Init (c_InputFPPRemotePlayFile* Parent);
     virtual void GetStateName (String & sName) { sName = CN_File; }
-    virtual void Start (String & FileName, uint32_t FrameId, uint32_t RemainingPlayCount);
+    virtual void Start (String & FileName, float SecondsElapsed, uint32_t RemainingPlayCount);
     virtual void Stop (void);
-    virtual bool Sync (String & FileName, uint32_t FrameId);
+    virtual bool Sync (String & FileName, float SecondsElapsed);
     virtual IRAM_ATTR void TimerPoll ();
 
 private:
@@ -93,6 +93,7 @@ private:
         uint32_t DataOffset;
         uint32_t ChannelCount;
     };
+    uint32_t LastPlayedFrameId = 0;
 
 }; // fsm_PlayFile_state_PlayingFile
 
@@ -103,14 +104,14 @@ public:
     virtual void Poll ();
     virtual void Init (c_InputFPPRemotePlayFile* Parent);
     virtual void GetStateName (String& sName) { sName = F("Stopping"); }
-    virtual void Start (String& FileName, uint32_t FrameId, uint32_t RemainingPlayCount);
+    virtual void Start (String& FileName, float SecondsElapsed, uint32_t RemainingPlayCount);
     virtual void Stop (void);
-    virtual bool Sync (String& FileName, uint32_t FrameId);
+    virtual bool Sync (String& FileName, float SecondsElapsed);
     virtual IRAM_ATTR void TimerPoll ();
 
 private:
-    String   FileName        = "";
-    uint32_t StartingFrameId = 0;
-    uint32_t PlayCount       = 0;
+    String   FileName            = "";
+    uint32_t StartingElapsedTime = 0.0;
+    uint32_t PlayCount           = 0;
 
 }; // fsm_PlayFile_state_Stopping

--- a/ESPixelStick/src/input/InputFPPRemotePlayItem.hpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayItem.hpp
@@ -29,9 +29,9 @@ public:
     virtual ~c_InputFPPRemotePlayItem ();
 
     virtual void     Poll           (uint8_t * Buffer, size_t BufferSize) = 0;
-    virtual void     Start          (String & FileName, uint32_t FrameId, uint32_t RemainingPlayCount) = 0;
+    virtual void     Start          (String & FileName, float SecondsElapsed, uint32_t RemainingPlayCount) = 0;
     virtual void     Stop           () = 0;
-    virtual void     Sync           (String & FileName, uint32_t FrameId) = 0;
+    virtual void     Sync           (String & FileName, float SecondsElapsed) = 0;
     virtual void     GetStatus      (JsonObject & jsonStatus) = 0;
     virtual bool     IsIdle         () = 0;
             String   GetFileName    () { return PlayItemName; }

--- a/ESPixelStick/src/input/InputFPPRemotePlayList.cpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayList.cpp
@@ -44,11 +44,11 @@ c_InputFPPRemotePlayList::~c_InputFPPRemotePlayList ()
 } // ~c_InputFPPRemotePlayList
 
 //-----------------------------------------------------------------------------
-void c_InputFPPRemotePlayList::Start (String & FileName, uint32_t FrameId, uint32_t PlayCount)
+void c_InputFPPRemotePlayList::Start (String & FileName, float ElapsedSeconds, uint32_t PlayCount)
 {
     // DEBUG_START;
 
-    pCurrentFsmState->Start (FileName, FrameId, PlayCount);
+    pCurrentFsmState->Start (FileName, ElapsedSeconds, PlayCount);
 
     // DEBUG_END;
 
@@ -66,11 +66,11 @@ void c_InputFPPRemotePlayList::Stop ()
 } // Stop
 
 //-----------------------------------------------------------------------------
-void c_InputFPPRemotePlayList::Sync (String & FileName, uint32_t FrameId)
+void c_InputFPPRemotePlayList::Sync (String & FileName, float ElapsedSeconds)
 {
     // DEBUG_START;
 
-    pCurrentFsmState->Sync (FileName, FrameId);
+    pCurrentFsmState->Sync (FileName, ElapsedSeconds);
 
     // DEBUG_END;
 

--- a/ESPixelStick/src/input/InputFPPRemotePlayList.hpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayList.hpp
@@ -31,9 +31,9 @@ public:
     c_InputFPPRemotePlayList (c_InputMgr::e_InputChannelIds InputChannelId);
     ~c_InputFPPRemotePlayList ();
 
-    virtual void Start (String & FileName, uint32_t FrameId, uint32_t PlayCount);
+    virtual void Start (String & FileName, float SecondsElapsed, uint32_t PlayCount);
     virtual void Stop  ();
-    virtual void Sync  (String & FileName, uint32_t FrameId);
+    virtual void Sync  (String & FileName, float SecondsElapsed);
     virtual void Poll  (uint8_t * Buffer, size_t BufferSize);
     virtual void GetStatus (JsonObject & jsonStatus);
     virtual bool IsIdle () { return (pCurrentFsmState == &fsm_PlayList_state_Idle_imp); }

--- a/ESPixelStick/src/input/InputFPPRemotePlayListFsm.cpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayListFsm.cpp
@@ -47,7 +47,7 @@ void fsm_PlayList_state_WaitForStart::Init (c_InputFPPRemotePlayList* Parent)
 } // fsm_PlayList_state_WaitForStart::Init
 
 //-----------------------------------------------------------------------------
-void fsm_PlayList_state_WaitForStart::Start (String& FileName, uint32_t, uint32_t)
+void fsm_PlayList_state_WaitForStart::Start (String & FileName, float, uint32_t)
 {
     // DEBUG_START;
 
@@ -115,7 +115,7 @@ void fsm_PlayList_state_Idle::Init (c_InputFPPRemotePlayList* Parent)
 } // fsm_PlayList_state_Idle::Init
 
 //-----------------------------------------------------------------------------
-void fsm_PlayList_state_Idle::Start (String &, uint32_t, uint32_t )
+void fsm_PlayList_state_Idle::Start (String &, float, uint32_t )
 {
     // DEBUG_START;
 
@@ -181,11 +181,11 @@ void fsm_PlayList_state_PlayingFile::Init (c_InputFPPRemotePlayList* Parent)
 } // fsm_PlayList_state_PlayingFile::Init
 
 //-----------------------------------------------------------------------------
-void fsm_PlayList_state_PlayingFile::Start (String & FileName, uint32_t FrameId, uint32_t PlayCount)
+void fsm_PlayList_state_PlayingFile::Start (String & FileName, float SecondsElapsed, uint32_t PlayCount)
 {
     // DEBUG_START;
 
-    pInputFPPRemotePlayList->pInputFPPRemotePlayItem->Start (FileName, FrameId, PlayCount);
+    pInputFPPRemotePlayList->pInputFPPRemotePlayItem->Start (FileName, SecondsElapsed, PlayCount);
 
     // DEBUG_END;
 
@@ -257,15 +257,15 @@ void fsm_PlayList_state_PlayingEffect::Init (c_InputFPPRemotePlayList* Parent)
 } // fsm_PlayList_state_PlayingEffect::Init
 
 //-----------------------------------------------------------------------------
-void fsm_PlayList_state_PlayingEffect::Start (String & FileName, uint32_t FrameId, uint32_t PlayCount)
+void fsm_PlayList_state_PlayingEffect::Start (String & FileName, float SecondsElapsed, uint32_t PlayCount)
 {
     // DEBUG_START;
 
     // DEBUG_V (String ("FileName: '") + String (FileName) + "'");
     // DEBUG_V (String ("FrameId: '") + String (FrameId) + "'");
 
-    pInputFPPRemotePlayList->pInputFPPRemotePlayItem->SetDuration (FrameId);
-    pInputFPPRemotePlayList->pInputFPPRemotePlayItem->Start (FileName, 0, PlayCount);
+    pInputFPPRemotePlayList->pInputFPPRemotePlayItem->SetDuration (SecondsElapsed);
+    pInputFPPRemotePlayList->pInputFPPRemotePlayItem->Start (FileName, 0.0, PlayCount);
     
     // DEBUG_END;
 
@@ -330,7 +330,7 @@ void fsm_PlayList_state_Paused::Init (c_InputFPPRemotePlayList* Parent)
 } // fsm_PlayList_state_Paused::Init
 
 //-----------------------------------------------------------------------------
-void fsm_PlayList_state_Paused::Start (String& , uint32_t , uint32_t )
+void fsm_PlayList_state_Paused::Start (String& , float , uint32_t )
 {
     // DEBUG_START;
 

--- a/ESPixelStick/src/input/InputFPPRemotePlayListFsm.hpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayListFsm.hpp
@@ -35,9 +35,9 @@ public:
     virtual void Poll (uint8_t * Buffer, size_t BufferSize) = 0;
     virtual void Init (c_InputFPPRemotePlayList * Parent) = 0;
     virtual void GetStateName (String & sName) = 0;
-    virtual void Start (String & FileName, uint32_t FrameId, uint32_t PlayCount) = 0;
+    virtual void Start (String & FileName, float SecondsElapsed, uint32_t PlayCount) = 0;
     virtual void Stop (void) = 0;
-    virtual bool Sync (String& sName, uint32_t FrameId) { return false; };
+    virtual bool Sync (String&, float) { return false; };
     virtual void GetStatus (JsonObject& jsonStatus) = 0;
     void GetDriverName (String& Name) { Name = "InputMgr"; }
 
@@ -53,7 +53,7 @@ public:
     virtual void Poll (uint8_t * Buffer, size_t BufferSize);
     virtual void Init (c_InputFPPRemotePlayList* Parent);
     virtual void GetStateName (String & sName) { sName = CN_Idle; }
-    virtual void Start (String & FileName, uint32_t FrameId, uint32_t PlayCount);
+    virtual void Start (String & FileName, float SecondsElapsed, uint32_t PlayCount);
     virtual void Stop (void);
     virtual void GetStatus (JsonObject& jsonStatus);
 
@@ -65,8 +65,8 @@ class fsm_PlayList_state_Idle : public fsm_PlayList_state
 public:
     virtual void Poll (uint8_t* Buffer, size_t BufferSize);
     virtual void Init (c_InputFPPRemotePlayList* Parent);
-    virtual void GetStateName (String& sName) { sName = CN_Idle; }
-    virtual void Start (String& FileName, uint32_t FrameId, uint32_t PlayCount);
+    virtual void GetStateName (String & sName) { sName = CN_Idle; }
+    virtual void Start (String & FileName, float SecondsElapsed, uint32_t PlayCount);
     virtual void Stop (void);
     virtual void GetStatus (JsonObject& jsonStatus);
 
@@ -79,7 +79,7 @@ public:
     virtual void Poll (uint8_t * Buffer, size_t BufferSize);
     virtual void Init (c_InputFPPRemotePlayList* Parent);
     virtual void GetStateName (String & sName) { sName = CN_File; }
-    virtual void Start (String & FileName, uint32_t FrameId, uint32_t PlayCount);
+    virtual void Start (String & FileName, float SecondsElapsed, uint32_t PlayCount);
     virtual void Stop (void);
     virtual void GetStatus (JsonObject& jsonStatus);
 
@@ -92,7 +92,7 @@ public:
     virtual void Poll (uint8_t * Buffer, size_t BufferSize);
     virtual void Init (c_InputFPPRemotePlayList* Parent);
     virtual void GetStateName (String & sName) { sName = CN_Effect; }
-    virtual void Start (String & FileName, uint32_t FrameId, uint32_t PlayCount);
+    virtual void Start (String & FileName, float SecondsElapsed, uint32_t PlayCount);
     virtual void Stop (void);
     virtual void GetStatus (JsonObject& jsonStatus);
 
@@ -105,7 +105,7 @@ public:
     virtual void Poll (uint8_t * Buffer, size_t BufferSize);
     virtual void Init (c_InputFPPRemotePlayList* Parent);
     virtual void GetStateName (String & sName) { sName = CN_Paused; }
-    virtual void Start (String & FileName, uint32_t FrameId, uint32_t PlayCount);
+    virtual void Start (String & FileName, float SecondsElapsed, uint32_t PlayCount);
     virtual void Stop (void);
     virtual void GetStatus (JsonObject& jsonStatus);
 

--- a/ESPixelStick/src/service/FPPDiscovery.cpp
+++ b/ESPixelStick/src/service/FPPDiscovery.cpp
@@ -206,10 +206,10 @@ void c_FPPDiscovery::ProcessReceivedUdpPacket (AsyncUDPPacket UDPpacket)
 
                 if (msPacket->sync_type == SYNC_FILE_SEQ)
                 {
-                    //FSEQ type, not media
+                    // FSEQ type, not media
                     // DEBUG_V (String (F ("Received FPP FSEQ sync packet")));
                     FppRemoteIp = UDPpacket.remoteIP ();
-                    ProcessSyncPacket (msPacket->sync_action, msPacket->filename, msPacket->frame_number, msPacket->seconds_elapsed);
+                    ProcessSyncPacket (msPacket->sync_action, String (msPacket->filename), msPacket->seconds_elapsed);
                 }
                 else if (msPacket->sync_type == SYNC_FILE_MEDIA)
                 {
@@ -299,7 +299,7 @@ void c_FPPDiscovery::ProcessReceivedUdpPacket (AsyncUDPPacket UDPpacket)
 } // ProcessReceivedUdpPacket
 
 //-----------------------------------------------------------------------------
-void c_FPPDiscovery::ProcessSyncPacket (uint8_t action, String FileName, uint32_t FrameId, float seconds_elapsed)
+void c_FPPDiscovery::ProcessSyncPacket (uint8_t action, String FileName, float SecondsElapsed)
 {
     // DEBUG_START;
     do // once
@@ -320,7 +320,7 @@ void c_FPPDiscovery::ProcessSyncPacket (uint8_t action, String FileName, uint32_
                 // DEBUG_V (String ("    FrameId: ") + FrameId);
 
                 MultiSyncStats.pktSyncSeqStart++;
-                StartPlaying (FileName, FrameId);
+                StartPlaying (FileName, SecondsElapsed);
                 break;
             }
 
@@ -352,7 +352,8 @@ void c_FPPDiscovery::ProcessSyncPacket (uint8_t action, String FileName, uint32_
                                   String(InputFPPRemotePlayFile.GetTimeOffset(),5));
                 */
                 MultiSyncStats.pktSyncSeqSync++;
-                InputFPPRemotePlayFile.Sync (FileName, FrameId);
+                // DEBUG_V (String ("SecondsElapsed: ") + String (SecondsElapsed));
+                InputFPPRemotePlayFile.Sync (FileName, SecondsElapsed);
                 break;
             }
 
@@ -924,7 +925,7 @@ void c_FPPDiscovery::ProcessFPPJson (AsyncWebServerRequest* request)
 } // ProcessFPPJson
 
 //-----------------------------------------------------------------------------
-void c_FPPDiscovery::StartPlaying (String & FileName, uint32_t FrameId)
+void c_FPPDiscovery::StartPlaying (String & FileName, float SecondsElapsed)
 {
     // DEBUG_START;
     // DEBUG_V (String("Open:: FileName: ") + FileName);
@@ -952,7 +953,7 @@ void c_FPPDiscovery::StartPlaying (String & FileName, uint32_t FrameId)
         }
         // DEBUG_V ("Asking for file to play");
 
-        InputFPPRemotePlayFile.Start (FileName, FrameId, 1);
+        InputFPPRemotePlayFile.Start (FileName, SecondsElapsed, 1);
 
     } while (false);
 

--- a/ESPixelStick/src/service/FPPDiscovery.h
+++ b/ESPixelStick/src/service/FPPDiscovery.h
@@ -41,7 +41,7 @@ private:
 
     AsyncUDP udp;
     void ProcessReceivedUdpPacket (AsyncUDPPacket _packet);
-    void ProcessSyncPacket (uint8_t action, String filename, uint32_t frame, float seconds_elapsed);
+    void ProcessSyncPacket (uint8_t action, String filename, float seconds_elapsed);
     void ProcessBlankPacket ();
     bool PlayingFile () { return !InputFPPRemotePlayFile.IsIdle (); }
 
@@ -55,7 +55,7 @@ private:
     void GetSysInfoJSON    (JsonObject& jsonResponse);
     void BuildFseqResponse (String fname, c_FileMgr::FileId fseq, String & resp);
     void StopPlaying       ();
-    void StartPlaying      (String & filename, uint32_t frameId);
+    void StartPlaying      (String & FileName, float SecondsElapsed);
     bool AllowedToRemotePlayFiles ();
     void GetDriverName     (String & Name) { Name = "FPPD"; }
 


### PR DESCRIPTION
This aligns us with the way FPP 5.3 works.