### PR TITLE
Cleaned up UI <->FS path to not include any string operations.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
           - target: "esp32_ttgo_t8"
             chip: "esp32"
           # mh et esp32 mini kit
-          - target: "d1_mini_mhetesp32minikit"
+          - target: "esp32_wt32eth01"
             chip: "esp32"
 
     runs-on: ubuntu-latest

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,5 +3,8 @@
     // for the documentation about the extensions.json format
     "recommendations": [
         "platformio.platformio-ide"
+    ],
+    "unwantedRecommendations": [
+        "ms-vscode.cpptools-extension-pack"
     ]
 }

--- a/ESPixelStick/ESPixelStick.ino
+++ b/ESPixelStick/ESPixelStick.ino
@@ -297,7 +297,9 @@ bool deserializeCore (JsonObject & json)
 
         dsDevice(DeviceConfig);
         FileMgr.SetConfig(DeviceConfig);
+        // DEBUG_V("");
         ConfigSaveNeeded |= NetworkMgr.SetConfig(DeviceConfig);
+        // DEBUG_V("");
         DataHasBeenAccepted = true;
 
     } while (false);

--- a/ESPixelStick/src/FileMgr.cpp
+++ b/ESPixelStick/src/FileMgr.cpp
@@ -367,14 +367,30 @@ bool c_FileMgr::SaveConfigFile (const String& FileName, const char * FileData)
 } // SaveConfigFile
 
 //-----------------------------------------------------------------------------
-bool c_FileMgr::SaveConfigFile (const String& FileName, JsonVariant& FileData)
+bool c_FileMgr::SaveConfigFile(const String &FileName, JsonDocument &FileData)
 {
     // DEBUG_START;
     bool Response = false;
-    String ConvertedFileData;
 
-    serializeJson (FileData, ConvertedFileData);
-    Response = SaveConfigFile (FileName, ConvertedFileData);
+    String CfgFileMessagePrefix = String(CN_Configuration_File_colon) + "'" + FileName + "' ";
+
+    fs::File file = LittleFS.open(FileName.c_str(), "w");
+    if (!file)
+    {
+        logcon(String(CN_stars) + CfgFileMessagePrefix + String(F("Could not open file for writing..")) + CN_stars);
+    }
+    else
+    {
+        file.seek(0, SeekSet);
+
+        size_t NumBytesSaved = serializeJson(FileData, file);
+
+        file.close();
+
+        logcon(CfgFileMessagePrefix + String(F("saved ")) + String(NumBytesSaved) + F(" bytes."));
+
+        Response = true;
+    }
 
     // DEBUG_END;
 

--- a/ESPixelStick/src/FileMgr.cpp
+++ b/ESPixelStick/src/FileMgr.cpp
@@ -155,8 +155,9 @@ void c_FileMgr::SetSpiIoPins ()
     {
         ESP_SD.end ();
     }
-
+#ifdef ARDUINO_ARCH_ESP32
     try
+#endif // def ARDUINO_ARCH_ESP32
     {
 #ifdef SUPPORT_SD_MMC
         pinMode(SD_CARD_DATA_0, PULLUP);
@@ -190,12 +191,14 @@ void c_FileMgr::SetSpiIoPins ()
             DescribeSdCardToUser ();
         }
     }
-    catch(const std::exception& e)
+#ifdef ARDUINO_ARCH_ESP32
+    catch (const std::exception &e)
     {
         logcon (String (F ("ERROR: Could not init the SD Card: "))+ e.what());
         SdCardInstalled = false;
     }
-    
+#endif // def ARDUINO_ARCH_ESP32
+
     // DEBUG_END;
 
 } // SetSpiIoPins

--- a/ESPixelStick/src/FileMgr.cpp
+++ b/ESPixelStick/src/FileMgr.cpp
@@ -299,7 +299,7 @@ bool c_FileMgr::LoadConfigFile (const String& FileName, DeserializationHandler H
             // logcon (CN_plussigns + RawFileData + CN_minussigns);
 	        // DEBUG_V (String ("                heap: ") + String (ESP.getFreeHeap ()));
     	    /// DEBUG_V (String (" getMaxFreeBlockSize: ") + String (ESP.getMaxFreeBlockSize ()));
-        	DEBUG_V (String ("           file.size: ") + String (file.size ()));
+        	// DEBUG_V (String ("           file.size: ") + String (file.size ()));
 	        // DEBUG_V (String ("Expected JsonDocSize: ") + String (JsonDocSize));
     	    // DEBUG_V (String ("    jsonDoc.capacity: ") + String (jsonDoc.capacity ()));
             break;

--- a/ESPixelStick/src/FileMgr.cpp
+++ b/ESPixelStick/src/FileMgr.cpp
@@ -298,7 +298,7 @@ bool c_FileMgr::LoadConfigFile (const String& FileName, DeserializationHandler H
             logcon (String(CN_stars) + CfgFileMessagePrefix + String (F ("Deserialzation Error. Error code = ")) + error.c_str () + CN_stars);
             // logcon (CN_plussigns + RawFileData + CN_minussigns);
 	        // DEBUG_V (String ("                heap: ") + String (ESP.getFreeHeap ()));
-    	    // DEBUG_V (String (" getMaxFreeBlockSize: ") + String (ESP.getMaxFreeBlockSize ()));
+    	    /// DEBUG_V (String (" getMaxFreeBlockSize: ") + String (ESP.getMaxFreeBlockSize ()));
         	DEBUG_V (String ("           file.size: ") + String (file.size ()));
 	        // DEBUG_V (String ("Expected JsonDocSize: ") + String (JsonDocSize));
     	    // DEBUG_V (String ("    jsonDoc.capacity: ") + String (jsonDoc.capacity ()));
@@ -517,7 +517,7 @@ bool c_FileMgr::ReadConfigFile (const String & FileName, byte * FileData, size_t
 
         GotFileData = true;
 
-        // DEBUG_V (FileData);
+        /// DEBUG_V (FileData);
 
     } while (false);
 

--- a/ESPixelStick/src/FileMgr.hpp
+++ b/ESPixelStick/src/FileMgr.hpp
@@ -19,14 +19,27 @@
 */
 
 #include "ESPixelStick.h"
-#include <FS.h>
 #include <LittleFS.h>
-#include <SD.h>
+#ifdef SUPPORT_SD_MMC
+#   include <SD_MMC.h>
+#else
+#   include <FS.h>
+#   include <SD.h>
+#endif // def SUPPORT_SD_MMC
 #include <map>
 
 #ifdef ARDUINO_ARCH_ESP32
-#	define SDFS SD
-#endif
+#   ifdef SUPPORT_SD_MMC
+#       define ESP_SD   SD_MMC
+#	    define ESP_SDFS SD_MMC
+#   else // !def SUPPORT_SD_MMC
+#       define ESP_SD   SD
+#	    define ESP_SDFS SD
+#   endif // !def SUPPORT_SD_MMC
+#else // !ARDUINO_ARCH_ESP32
+#   define ESP_SD   SD
+#   define ESP_SDFS SDFS
+#endif // !ARDUINO_ARCH_ESP32
 
 class c_FileMgr
 {
@@ -109,9 +122,10 @@ private:
 #define MaxOpenFiles 5
     struct FileListEntry_t
     {
-        FileId handle;
-        File   info;
-        int    entryId;
+        FileId  handle;
+        File    info;
+        size_t  size;
+        int     entryId;
     };
     FileListEntry_t FileList[MaxOpenFiles];
     int FileListFindSdFileHandle (FileId HandleToFind);

--- a/ESPixelStick/src/FileMgr.hpp
+++ b/ESPixelStick/src/FileMgr.hpp
@@ -69,7 +69,7 @@ public:
     void   DeleteConfigFile (const String & FileName);
     bool   SaveConfigFile   (const String & FileName, String & FileData);
     bool   SaveConfigFile   (const String & FileName, const char * FileData);
-    bool   SaveConfigFile   (const String & FileName, JsonVariant & FileData);
+    bool   SaveConfigFile   (const String & FileName, JsonDocument & FileData);
     bool   ReadConfigFile   (const String & FileName, String & FileData);
     bool   ReadConfigFile   (const String & FileName, JsonDocument & FileData);
     bool   ReadConfigFile   (const String & FileName, byte * FileData, size_t maxlen);

--- a/ESPixelStick/src/GPIO_Defs.hpp
+++ b/ESPixelStick/src/GPIO_Defs.hpp
@@ -105,7 +105,9 @@ typedef enum
 #   include "GPIO_Defs_ESP8266_ESP01S.hpp"
 #elif defined (BOARD_ESPS_V3)
 #   include "GPIO_Defs_ESP8266_ESPS_V3.hpp"
-#elif defined (ARDUINO_ARCH_ESP8266)
+#elif defined(BOARD_ESP32_QUINLED_ETH)
+#   include "GPIO_Defs_ESP32_QUINLED_ETH.hpp"
+#elif defined(ARDUINO_ARCH_ESP8266)
 #   include "GPIO_Defs_ESP8266_Generic.hpp"
 #elif defined (ARDUINO_ARCH_ESP32)
 #   include "GPIO_Defs_ESP32_generic.hpp"

--- a/ESPixelStick/src/GPIO_Defs.hpp
+++ b/ESPixelStick/src/GPIO_Defs.hpp
@@ -79,6 +79,7 @@ typedef enum
 // #define BOARD_ESP32_D1_MINI_ETH
 // #define BOARD_ESP32_LOLIN_D32_PRO_ETH
 // #define BOARD_ESP32_MH_ET_LIVE_MiniKit
+// #define BOARD_ESP32_WT32ETH01
 
 #define SUPPORT_OutputType_UCS1903
 #define SUPPORT_OutputType_GS8208
@@ -98,6 +99,8 @@ typedef enum
 #   include "GPIO_Defs_ESP32_D1_MINI_ETH.hpp"
 #elif defined (BOARD_ESP32_MH_ET_LIVE_MiniKit)
 #   include "GPIO_Defs_ESP32_MH_ET_LIVE_MiniKit.hpp"
+#elif defined (BOARD_ESP32_WT32ETH01)
+#   include "GPIO_Defs_ESP32_WT32ETH01.hpp"
 #elif defined (BOARD_ESP01S)
 #   include "GPIO_Defs_ESP8266_ESP01S.hpp"
 #elif defined (BOARD_ESPS_V3)

--- a/ESPixelStick/src/GPIO_Defs.hpp
+++ b/ESPixelStick/src/GPIO_Defs.hpp
@@ -72,45 +72,42 @@ typedef enum
 } uart_port_t;
 #endif // def ARDUINO_ARCH_ESP8266
 
-// #define BOARD_ESP01S
-// #define BOARD_ESPS_V3
-// #define BOARD_ESP32_CAM
-// #define BOARD_ESP32_TTGO_T8
-// #define BOARD_ESP32_D1_MINI_ETH
-// #define BOARD_ESP32_LOLIN_D32_PRO_ETH
-// #define BOARD_ESP32_MH_ET_LIVE_MiniKit
-// #define BOARD_ESP32_WT32ETH01
-
 #define SUPPORT_OutputType_UCS1903
 #define SUPPORT_OutputType_GS8208
 
 // Platform specific GPIO definitions
 #if defined (BOARD_ESP32_CAM)
 #   include "GPIO_Defs_ESP32_CAM.hpp"
-#elif defined (BOARD_ESP32_TTGO_T8)
-#   include "GPIO_Defs_ESP32_TTGO_T8.hpp"
-#elif defined (BOARD_ESP32_LOLIN_D32_PRO)
-#   include "GPIO_Defs_ESP32_generic.hpp"
-#elif defined (BOARD_ESP32_LOLIN_D32_PRO_ETH)
-#   include "GPIO_Defs_ESP32_LoLin_D32_PRO_ETH.hpp"
-#elif defined (BOARD_ESP32_D1_MINI)
-#   include "GPIO_Defs_ESP32_D1_MINI.hpp"
 #elif defined (BOARD_ESP32_D1_MINI_ETH)
 #   include "GPIO_Defs_ESP32_D1_MINI_ETH.hpp"
+#elif defined (BOARD_ESP32_D1_MINI)
+#   include "GPIO_Defs_ESP32_D1_MINI.hpp"
+#elif defined (BOARD_ESP32_LOLIN_D32_PRO_ETH)
+#   include "GPIO_Defs_ESP32_LoLin_D32_PRO_ETH.hpp"
+#elif defined (BOARD_ESP32_LOLIN_D32_PRO)
+#   include "GPIO_Defs_ESP32_generic.hpp"
 #elif defined (BOARD_ESP32_MH_ET_LIVE_MiniKit)
 #   include "GPIO_Defs_ESP32_MH_ET_LIVE_MiniKit.hpp"
+#elif defined(BOARD_ESP32_QUINLED_QUAD_ETH)
+#   include "GPIO_Defs_ESP32_QUINLED_QUAD_ETH.hpp"
+#elif defined(BOARD_ESP32_QUINLED_QUAD)
+#   include "GPIO_Defs_ESP32_QUINLED_QUAD.hpp"
+#elif defined(BOARD_ESP32_QUINLED_UNO_ETH)
+#   include "GPIO_Defs_ESP32_QUINLED_UNO_ETH.hpp"
+#elif defined(BOARD_ESP32_QUINLED_UNO)
+#   include "GPIO_Defs_ESP32_QUINLED_UNO.hpp"
+#elif defined (BOARD_ESP32_TTGO_T8)
+#   include "GPIO_Defs_ESP32_TTGO_T8.hpp"
 #elif defined (BOARD_ESP32_WT32ETH01)
 #   include "GPIO_Defs_ESP32_WT32ETH01.hpp"
 #elif defined (BOARD_ESP01S)
 #   include "GPIO_Defs_ESP8266_ESP01S.hpp"
 #elif defined (BOARD_ESPS_V3)
 #   include "GPIO_Defs_ESP8266_ESPS_V3.hpp"
-#elif defined(BOARD_ESP32_QUINLED_ETH)
-#   include "GPIO_Defs_ESP32_QUINLED_ETH.hpp"
-#elif defined(ARDUINO_ARCH_ESP8266)
-#   include "GPIO_Defs_ESP8266_Generic.hpp"
 #elif defined (ARDUINO_ARCH_ESP32)
 #   include "GPIO_Defs_ESP32_generic.hpp"
+#elif defined(ARDUINO_ARCH_ESP8266)
+#   include "GPIO_Defs_ESP8266_Generic.hpp"
 #else
 #   error "No valid platform definition"
 #endif // ndef platform specific GPIO definitions

--- a/ESPixelStick/src/GPIO_Defs_ESP32_CAM.hpp
+++ b/ESPixelStick/src/GPIO_Defs_ESP32_CAM.hpp
@@ -32,7 +32,18 @@
 #define LED_FLASH_OFF           HIGH
 
 // File Manager
-#define SD_CARD_MISO_PIN        gpio_num_t::GPIO_NUM_2
-#define SD_CARD_MOSI_PIN        gpio_num_t::GPIO_NUM_15
-#define SD_CARD_CLK_PIN         gpio_num_t::GPIO_NUM_14
-#define SD_CARD_CS_PIN          gpio_num_t::GPIO_NUM_13
+// #define USE_MISO_PULLUP
+// #define SUPPORT_SD_MMC
+// #ifdef SUPPORT_SD_MMC
+#   define SD_CARD_CMD             gpio_num_t::GPIO_NUM_15
+#   define SD_CARD_CLK             gpio_num_t::GPIO_NUM_14
+#   define SD_CARD_DATA_0          gpio_num_t::GPIO_NUM_2
+#   define SD_CARD_DATA_1          gpio_num_t::GPIO_NUM_4
+#   define SD_CARD_DATA_2          gpio_num_t::GPIO_NUM_12
+#   define SD_CARD_DATA_3          gpio_num_t::GPIO_NUM_13
+// #else
+#   define SD_CARD_MISO_PIN        gpio_num_t::GPIO_NUM_2
+#   define SD_CARD_MOSI_PIN        gpio_num_t::GPIO_NUM_15
+#   define SD_CARD_CLK_PIN         gpio_num_t::GPIO_NUM_14
+#   define SD_CARD_CS_PIN          gpio_num_t::GPIO_NUM_13
+// #endif // SUPPORT SD

--- a/ESPixelStick/src/GPIO_Defs_ESP32_QUINLED_ETH.hpp
+++ b/ESPixelStick/src/GPIO_Defs_ESP32_QUINLED_ETH.hpp
@@ -1,0 +1,86 @@
+#pragma once
+/*
+ * GPIO_Defs_ESP32_QUINLED_ETH.hpp - Output Management class
+ *
+ * Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+ * Copyright (c) 2021 Shelby Merrick
+ * http://www.forkineye.com
+ *
+ *  This program is provided free for you to use in any way that you wish,
+ *  subject to the laws and regulations where you are using it.  Due diligence
+ *  is strongly suggested before using this code.  Please give credit where due.
+ *
+ *  The Author makes no warranty of any kind, express or implied, with regard
+ *  to this program or the documentation contained in this document.  The
+ *  Author shall not be liable in any event for incidental or consequential
+ *  damages in connection with, or arising out of, the furnishing, performance
+ *  or use of these programs.
+ *
+ */
+
+#define SUPPORT_ETHERNET
+
+//Output Manager
+#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
+#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_4
+#define UART_LAST               OutputChannelId_UART_1
+
+#define SUPPORT_RMT_OUTPUT
+#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_0
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_5
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_16
+#define RMT_LAST                OutputChannelId_RMT_3
+
+// #define SUPPORT_OutputType_WS2801
+// #define SUPPORT_OutputType_APA102
+// #define SUPPORT_OutputType_TM1814
+// #define SUPPORT_OutputType_TLS3001
+
+// #define SUPPORT_RELAY_OUTPUT
+
+#if defined(SUPPORT_OutputType_WS2801) || defined(SUPPORT_OutputType_APA102)
+#   define SUPPORT_SPI_OUTPUT
+
+// SPI Output
+#  define DEFAULT_SPI_DATA_GPIO  gpio_num_t::GPIO_NUM_15
+#  define DEFAULT_SPI_CLOCK_GPIO gpio_num_t::GPIO_NUM_25
+
+#endif // defined(SUPPORT_OutputType_WS2801) || defined(SUPPORT_OutputType_TM1814)
+
+// File Manager
+#define SD_CARD_MISO_PIN        gpio_num_t::GPIO_NUM_12
+#define SD_CARD_MOSI_PIN        gpio_num_t::GPIO_NUM_13
+#define SD_CARD_CLK_PIN         gpio_num_t::GPIO_NUM_14
+#define SD_CARD_CS_PIN          gpio_num_t::GPIO_NUM_15
+
+// #include <ETH.h>
+#include "network/ETH_m.h"
+
+/*
+   * ETH_CLOCK_GPIO0_IN   - default: external clock from crystal oscillator
+   * ETH_CLOCK_GPIO0_OUT  - 50MHz clock from internal APLL output on GPIO0 - possibly an inverter is needed for LAN8720
+   * ETH_CLOCK_GPIO16_OUT - 50MHz clock from internal APLL output on GPIO16 - possibly an inverter is needed for LAN8720
+   * ETH_CLOCK_GPIO17_OUT - 50MHz clock from internal APLL inverted output on GPIO17 - tested with LAN8720
+*/
+#define DEFAULT_ETH_CLK_MODE ETH_CLOCK_GPIO0_IN
+
+// Pin# of the enable signal for the external crystal oscillator (-1 to disable for internal APLL source)
+#define DEFAULT_ETH_POWER_PIN          gpio_num_t::GPIO_NUM_15
+#define DEFAULT_ETH_POWER_PIN_ACTIVE   HIGH
+
+// Type of the Ethernet PHY (LAN8720 or TLK110)
+#define DEFAULT_ETH_TYPE    ETH_PHY_LAN8720
+
+// I2C-address of Ethernet PHY (0 or 1 for LAN8720, 31 for TLK110)
+// #define ETH_ADDR_PHY_LAN8720    0
+#define ETH_ADDR_PHY_LAN8720    1
+#define ETH_ADDR_PHY_TLK110     31
+#define DEFAULT_ETH_ADDR        ETH_ADDR_PHY_LAN8720
+#define DEFAULT_ETH_TXEN        gpio_num_t::GPIO_NUM_21
+#define DEFAULT_ETH_TXD0        gpio_num_t::GPIO_NUM_19
+#define DEFAULT_ETH_TXD1        gpio_num_t::GPIO_NUM_22
+#define DEFAULT_ETH_CRSDV       gpio_num_t::GPIO_NUM_27
+#define DEFAULT_ETH_RXD0        gpio_num_t::GPIO_NUM_25
+#define DEFAULT_ETH_RXD1        gpio_num_t::GPIO_NUM_26
+#define DEFAULT_ETH_MDC_PIN     gpio_num_t::GPIO_NUM_23
+#define DEFAULT_ETH_MDIO_PIN    gpio_num_t::GPIO_NUM_18

--- a/ESPixelStick/src/GPIO_Defs_ESP32_QUINLED_QUAD.hpp
+++ b/ESPixelStick/src/GPIO_Defs_ESP32_QUINLED_QUAD.hpp
@@ -1,0 +1,35 @@
+#pragma once
+/*
+ * GPIO_Defs_ESP32_QUINLED_QUAD.hpp - Output Management class
+ *
+ * Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+ * Copyright (c) 2021 Shelby Merrick
+ * http://www.forkineye.com
+ *
+ *  This program is provided free for you to use in any way that you wish,
+ *  subject to the laws and regulations where you are using it.  Due diligence
+ *  is strongly suggested before using this code.  Please give credit where due.
+ *
+ *  The Author makes no warranty of any kind, express or implied, with regard
+ *  to this program or the documentation contained in this document.  The
+ *  Author shall not be liable in any event for incidental or consequential
+ *  damages in connection with, or arising out of, the furnishing, performance
+ *  or use of these programs.
+ *
+ */
+
+//Output Manager
+#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
+#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_4
+#define UART_LAST               OutputChannelId_UART_2
+
+#define SUPPORT_RMT_OUTPUT
+#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_0
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_5
+#define RMT_LAST                OutputChannelId_RMT_2
+
+// File Manager
+#define SD_CARD_MISO_PIN        gpio_num_t::GPIO_NUM_12
+#define SD_CARD_MOSI_PIN        gpio_num_t::GPIO_NUM_13
+#define SD_CARD_CLK_PIN         gpio_num_t::GPIO_NUM_14
+#define SD_CARD_CS_PIN          gpio_num_t::GPIO_NUM_15

--- a/ESPixelStick/src/GPIO_Defs_ESP32_QUINLED_QUAD_ETH.hpp
+++ b/ESPixelStick/src/GPIO_Defs_ESP32_QUINLED_QUAD_ETH.hpp
@@ -1,0 +1,69 @@
+#pragma once
+/*
+ * GPIO_Defs_ESP32_QUINLED_QUAD_ETH.hpp - Output Management class
+ *
+ * Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+ * Copyright (c) 2021 Shelby Merrick
+ * http://www.forkineye.com
+ *
+ *  This program is provided free for you to use in any way that you wish,
+ *  subject to the laws and regulations where you are using it.  Due diligence
+ *  is strongly suggested before using this code.  Please give credit where due.
+ *
+ *  The Author makes no warranty of any kind, express or implied, with regard
+ *  to this program or the documentation contained in this document.  The
+ *  Author shall not be liable in any event for incidental or consequential
+ *  damages in connection with, or arising out of, the furnishing, performance
+ *  or use of these programs.
+ *
+ */
+
+#define SUPPORT_ETHERNET
+
+//Output Manager
+#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
+#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_4
+#define UART_LAST               OutputChannelId_UART_2
+
+#define SUPPORT_RMT_OUTPUT
+#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_0
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_5
+#define RMT_LAST                OutputChannelId_RMT_2
+
+// File Manager
+#define SD_CARD_MISO_PIN        gpio_num_t::GPIO_NUM_12
+#define SD_CARD_MOSI_PIN        gpio_num_t::GPIO_NUM_13
+#define SD_CARD_CLK_PIN         gpio_num_t::GPIO_NUM_14
+#define SD_CARD_CS_PIN          gpio_num_t::GPIO_NUM_15
+
+// #include <ETH.h>
+#include "network/ETH_m.h"
+
+/*
+   * ETH_CLOCK_GPIO0_IN   - default: external clock from crystal oscillator
+   * ETH_CLOCK_GPIO0_OUT  - 50MHz clock from internal APLL output on GPIO0 - possibly an inverter is needed for LAN8720
+   * ETH_CLOCK_GPIO16_OUT - 50MHz clock from internal APLL output on GPIO16 - possibly an inverter is needed for LAN8720
+   * ETH_CLOCK_GPIO17_OUT - 50MHz clock from internal APLL inverted output on GPIO17 - tested with LAN8720
+*/
+#define DEFAULT_ETH_CLK_MODE ETH_CLOCK_GPIO0_IN
+
+// Pin# of the enable signal for the external crystal oscillator (-1 to disable for internal APLL source)
+#define DEFAULT_ETH_POWER_PIN          gpio_num_t::GPIO_NUM_15
+#define DEFAULT_ETH_POWER_PIN_ACTIVE   HIGH
+
+// Type of the Ethernet PHY (LAN8720 or TLK110)
+#define DEFAULT_ETH_TYPE    ETH_PHY_LAN8720
+
+// I2C-address of Ethernet PHY (0 or 1 for LAN8720, 31 for TLK110)
+// #define ETH_ADDR_PHY_LAN8720    0
+#define ETH_ADDR_PHY_LAN8720    1
+#define ETH_ADDR_PHY_TLK110     31
+#define DEFAULT_ETH_ADDR        ETH_ADDR_PHY_LAN8720
+#define DEFAULT_ETH_TXEN        gpio_num_t::GPIO_NUM_21
+#define DEFAULT_ETH_TXD0        gpio_num_t::GPIO_NUM_19
+#define DEFAULT_ETH_TXD1        gpio_num_t::GPIO_NUM_22
+#define DEFAULT_ETH_CRSDV       gpio_num_t::GPIO_NUM_27
+#define DEFAULT_ETH_RXD0        gpio_num_t::GPIO_NUM_25
+#define DEFAULT_ETH_RXD1        gpio_num_t::GPIO_NUM_26
+#define DEFAULT_ETH_MDC_PIN     gpio_num_t::GPIO_NUM_23
+#define DEFAULT_ETH_MDIO_PIN    gpio_num_t::GPIO_NUM_18

--- a/ESPixelStick/src/GPIO_Defs_ESP32_QUINLED_UNO.hpp
+++ b/ESPixelStick/src/GPIO_Defs_ESP32_QUINLED_UNO.hpp
@@ -1,0 +1,29 @@
+#pragma once
+/*
+ * GPIO_Defs_ESP32_QUINLED_UNO.hpp - Output Management class
+ *
+ * Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+ * Copyright (c) 2021 Shelby Merrick
+ * http://www.forkineye.com
+ *
+ *  This program is provided free for you to use in any way that you wish,
+ *  subject to the laws and regulations where you are using it.  Due diligence
+ *  is strongly suggested before using this code.  Please give credit where due.
+ *
+ *  The Author makes no warranty of any kind, express or implied, with regard
+ *  to this program or the documentation contained in this document.  The
+ *  Author shall not be liable in any event for incidental or consequential
+ *  damages in connection with, or arising out of, the furnishing, performance
+ *  or use of these programs.
+ *
+ */
+
+// Output Manager
+#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
+#define UART_LAST               OutputChannelId_UART_1
+
+// File Manager
+#define SD_CARD_MISO_PIN gpio_num_t::GPIO_NUM_12
+#define SD_CARD_MOSI_PIN gpio_num_t::GPIO_NUM_13
+#define SD_CARD_CLK_PIN gpio_num_t::GPIO_NUM_14
+#define SD_CARD_CS_PIN gpio_num_t::GPIO_NUM_15

--- a/ESPixelStick/src/GPIO_Defs_ESP32_QUINLED_UNO_ETH.hpp
+++ b/ESPixelStick/src/GPIO_Defs_ESP32_QUINLED_UNO_ETH.hpp
@@ -1,6 +1,6 @@
 #pragma once
 /*
- * GPIO_Defs_ESP32_QUINLED_ETH.hpp - Output Management class
+ * GPIO_Defs_ESP32_QUINLED_UNO_ETH.hpp - Output Management class
  *
  * Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
  * Copyright (c) 2021 Shelby Merrick
@@ -22,30 +22,7 @@
 
 //Output Manager
 #define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_4
 #define UART_LAST               OutputChannelId_UART_1
-
-#define SUPPORT_RMT_OUTPUT
-#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_0
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_5
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_16
-#define RMT_LAST                OutputChannelId_RMT_3
-
-// #define SUPPORT_OutputType_WS2801
-// #define SUPPORT_OutputType_APA102
-// #define SUPPORT_OutputType_TM1814
-// #define SUPPORT_OutputType_TLS3001
-
-// #define SUPPORT_RELAY_OUTPUT
-
-#if defined(SUPPORT_OutputType_WS2801) || defined(SUPPORT_OutputType_APA102)
-#   define SUPPORT_SPI_OUTPUT
-
-// SPI Output
-#  define DEFAULT_SPI_DATA_GPIO  gpio_num_t::GPIO_NUM_15
-#  define DEFAULT_SPI_CLOCK_GPIO gpio_num_t::GPIO_NUM_25
-
-#endif // defined(SUPPORT_OutputType_WS2801) || defined(SUPPORT_OutputType_TM1814)
 
 // File Manager
 #define SD_CARD_MISO_PIN        gpio_num_t::GPIO_NUM_12

--- a/ESPixelStick/src/GPIO_Defs_ESP32_WT32ETH01.hpp
+++ b/ESPixelStick/src/GPIO_Defs_ESP32_WT32ETH01.hpp
@@ -1,0 +1,87 @@
+#pragma once
+/*
+* GPIO_Defs_ESP32_WT32ETH01.hpp - Output Management class
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2021 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*/
+
+#define SUPPORT_ETHERNET
+
+//Output Manager
+#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
+#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_4
+#define UART_LAST               OutputChannelId_UART_1
+
+#define SUPPORT_RMT_OUTPUT
+#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_0
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_5
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_16
+#define RMT_LAST                OutputChannelId_RMT_3
+
+// #define SUPPORT_OutputType_WS2801
+// #define SUPPORT_OutputType_APA102
+// #define SUPPORT_OutputType_TM1814
+// #define SUPPORT_OutputType_TLS3001
+
+// #define SUPPORT_RELAY_OUTPUT
+
+#if defined(SUPPORT_OutputType_WS2801) || defined(SUPPORT_OutputType_APA102)
+#   define SUPPORT_SPI_OUTPUT
+
+// SPI Output
+#define DEFAULT_SPI_DATA_GPIO  gpio_num_t::GPIO_NUM_15
+#define DEFAULT_SPI_CLOCK_GPIO gpio_num_t::GPIO_NUM_25
+
+#endif // defined(SUPPORT_OutputType_WS2801) || defined(SUPPORT_OutputType_TM1814)
+
+// File Manager
+#define SD_CARD_MISO_PIN        gpio_num_t::GPIO_NUM_12
+#define SD_CARD_MOSI_PIN        gpio_num_t::GPIO_NUM_13
+#define SD_CARD_CLK_PIN         gpio_num_t::GPIO_NUM_14
+#define SD_CARD_CS_PIN          gpio_num_t::GPIO_NUM_15
+
+// #include <ETH.h>
+#include "network/ETH_m.h"
+
+/*
+   * ETH_CLOCK_GPIO0_IN   - default: external clock from crystal oscillator
+   * ETH_CLOCK_GPIO0_OUT  - 50MHz clock from internal APLL output on GPIO0 - possibly an inverter is needed for LAN8720
+   * ETH_CLOCK_GPIO16_OUT - 50MHz clock from internal APLL output on GPIO16 - possibly an inverter is needed for LAN8720
+   * ETH_CLOCK_GPIO17_OUT - 50MHz clock from internal APLL inverted output on GPIO17 - tested with LAN8720
+*/
+#define DEFAULT_ETH_CLK_MODE ETH_CLOCK_GPIO0_IN
+
+// Pin# of the enable signal for the external crystal oscillator (-1 to disable for internal APLL source)
+#define DEFAULT_ETH_POWER_PIN          gpio_num_t::GPIO_NUM_16
+#define DEFAULT_ETH_POWER_PIN_ACTIVE   HIGH
+
+// Type of the Ethernet PHY (LAN8720 or TLK110)
+#define DEFAULT_ETH_TYPE    ETH_PHY_LAN8720
+
+// I2C-address of Ethernet PHY (0 or 1 for LAN8720, 31 for TLK110)
+// #define ETH_ADDR_PHY_LAN8720    0
+#define ETH_ADDR_PHY_LAN8720    1
+#define ETH_ADDR_PHY_TLK110     31
+#define DEFAULT_ETH_ADDR        ETH_ADDR_PHY_LAN8720
+#define DEFAULT_ETH_TXEN        gpio_num_t::GPIO_NUM_21
+#define DEFAULT_ETH_TXD0        gpio_num_t::GPIO_NUM_19
+#define DEFAULT_ETH_TXD1        gpio_num_t::GPIO_NUM_22
+#define DEFAULT_ETH_CRSDV       gpio_num_t::GPIO_NUM_27
+#define DEFAULT_ETH_RXD0        gpio_num_t::GPIO_NUM_25
+#define DEFAULT_ETH_RXD1        gpio_num_t::GPIO_NUM_26
+#define DEFAULT_ETH_MDC_PIN     gpio_num_t::GPIO_NUM_23
+#define DEFAULT_ETH_MDIO_PIN    gpio_num_t::GPIO_NUM_18
+

--- a/ESPixelStick/src/WebMgr.cpp
+++ b/ESPixelStick/src/WebMgr.cpp
@@ -244,7 +244,7 @@ void c_WebMgr::init ()
         String filename = request->url ().substring (String ("/download").length ());
         // DEBUG_V (String ("filename: ") + String (filename));
 
-        AsyncWebServerResponse* response = new AsyncFileResponse (SDFS, filename, "application/octet-stream", true);
+        AsyncWebServerResponse* response = new AsyncFileResponse (ESP_SDFS, filename, "application/octet-stream", true);
         request->send (response);
 
         // DEBUG_V ("Send File Done");

--- a/ESPixelStick/src/WebMgr.cpp
+++ b/ESPixelStick/src/WebMgr.cpp
@@ -341,14 +341,6 @@ void c_WebMgr::GetConfiguration ()
     webJsonDoc.clear ();
     JsonObject JsonSystemConfig = webJsonDoc.createNestedObject (CN_system);
     GetConfig (JsonSystemConfig);
-    // DEBUG_V ("");
-
-    // JsonObject JsonOutputConfig = webJsonDoc.createNestedObject (F ("outputs"));
-    // OutputMgr.GetConfig (JsonOutputConfig);
-    // DEBUG_V ("");
-
-    // JsonObject JsonInputConfig = webJsonDoc.createNestedObject (F ("inputs"));
-    // InputMgr.GetConfig (JsonInputConfig);
 
     // now make it something we can transmit
     serializeJson (webJsonDoc, WebSocketFrameCollectionBuffer);
@@ -949,7 +941,7 @@ bool c_WebMgr::processCmdSet (JsonObject & jsonCmd)
 
     do // once
     {
-        if (jsonCmd.containsKey (CN_device))
+        if (jsonCmd.containsKey(CN_device) | jsonCmd.containsKey(CN_system))
         {
             // DEBUG_V ("device/network");
             extern void SetConfig (const char* DataString);

--- a/ESPixelStick/src/WebMgr.hpp
+++ b/ESPixelStick/src/WebMgr.hpp
@@ -54,7 +54,7 @@ private:
     EspalexaDevice *       pAlexaDevice = nullptr;
 
 #ifdef ARDUINO_ARCH_ESP32
-#   define WebSocketFrameCollectionBufferSize (8*1024)
+#   define WebSocketFrameCollectionBufferSize (10*1024)
 #else
 #   define WebSocketFrameCollectionBufferSize (3*1024)
 #endif // def ARDUINO_ARCH_ESP8266

--- a/ESPixelStick/src/WebMgr.hpp
+++ b/ESPixelStick/src/WebMgr.hpp
@@ -52,13 +52,17 @@ private:
     EFUpdate               efupdate;
     DeviceCallbackFunction pAlexaCallback = nullptr;
     EspalexaDevice *       pAlexaDevice = nullptr;
+    char *pWebSocketFrameCollectionBuffer = nullptr;
 
 #ifdef ARDUINO_ARCH_ESP32
-#   define WebSocketFrameCollectionBufferSize (10*1024)
-#else
+#   ifdef BOARD_HAS_PSRAM
+#      define WebSocketFrameCollectionBufferSize (20 * 1024)
+#   else // no PSRAM use heap
+#      define WebSocketFrameCollectionBufferSize (10 * 1024)
+#   endif // ! def BOARD_HAS_PSRAM
+#else // esp8266
 #   define WebSocketFrameCollectionBufferSize (3*1024)
 #endif // def ARDUINO_ARCH_ESP8266
-    char WebSocketFrameCollectionBuffer[WebSocketFrameCollectionBufferSize + 1];
 
     /// Valid "Simple" message types
     enum SimpleMessage
@@ -74,7 +78,7 @@ private:
     void onWsEvent                  (AsyncWebSocket* server, AsyncWebSocketClient* client, AwsEventType type, void* arg, uint8_t* data, size_t len);
     void ProcessVseriesRequests     (AsyncWebSocketClient  * client);
     void ProcessGseriesRequests     (AsyncWebSocketClient  * client);
-    void ProcessReceivedJsonMessage (DynamicJsonDocument   & webJsonDoc, AsyncWebSocketClient  * client);
+    void ProcessReceivedJsonMessage (AsyncWebSocketClient  * client);
     void processCmd                 (AsyncWebSocketClient  * client,  JsonObject & jsonCmd );
     void processCmdGet              (JsonObject & jsonCmd);
     bool processCmdSet              (JsonObject & jsonCmd);
@@ -92,7 +96,32 @@ private:
     void GetInputOptions            ();
     void GetOutputOptions           ();
 
-protected:
+#ifdef BOARD_HAS_PSRAM
+
+    struct SpiRamAllocator
+    {
+        void *allocate(size_t size)
+        {
+            return ps_malloc(size);
+        }
+
+        void deallocate(void *pointer)
+        {
+            free(pointer);
+        }
+
+        void *reallocate(void *ptr, size_t new_size)
+        {
+            return ps_realloc(ptr, new_size);
+        }
+    };
+
+    using WebJsonDocument = BasicJsonDocument<SpiRamAllocator>;
+#else
+    using WebJsonDocument = DynamicJsonDocument;
+#endif // def BOARD_HAS_PSRAM
+
+    WebJsonDocument *WebJsonDoc = nullptr;
 
 }; // c_WebMgr
 

--- a/ESPixelStick/src/input/InputFPPRemotePlayFile.cpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayFile.cpp
@@ -49,7 +49,7 @@ static void TimerPollHandlerTask (void* pvParameters)
         // we start suspended
         vTaskSuspend (NULL); //Suspend Own Task
         // DEBUG_V ("");
-        // InputFpp->TimerPoll ();
+        InputFpp->TimerPoll ();
 
     } while (true);
     // DEBUG_END;
@@ -149,7 +149,7 @@ void c_InputFPPRemotePlayFile::Poll (uint8_t * _Buffer, size_t _BufferSize)
     Buffer = _Buffer;
     BufferSize = _BufferSize;
 
-    TimerPoll ();
+    // TimerPoll ();
     pCurrentFsmState->Poll ();
 
     // Show that we have received a poll

--- a/ESPixelStick/src/input/InputFPPRemotePlayFile.cpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayFile.cpp
@@ -49,7 +49,7 @@ static void TimerPollHandlerTask (void* pvParameters)
         // we start suspended
         vTaskSuspend (NULL); //Suspend Own Task
         // DEBUG_V ("");
-        InputFpp->TimerPoll ();
+        // InputFpp->TimerPoll ();
 
     } while (true);
     // DEBUG_END;
@@ -149,7 +149,7 @@ void c_InputFPPRemotePlayFile::Poll (uint8_t * _Buffer, size_t _BufferSize)
     Buffer = _Buffer;
     BufferSize = _BufferSize;
 
-    // pCurrentFsmState->TimerPoll ();
+    TimerPoll ();
     pCurrentFsmState->Poll ();
 
     // Show that we have received a poll

--- a/ESPixelStick/src/input/InputFPPRemotePlayFile.hpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayFile.hpp
@@ -111,8 +111,8 @@ private:
 
 #ifdef ARDUINO_ARCH_ESP32
     TaskHandle_t TimerPollTaskHandle = NULL;
-// #   define TimerPollHandlerTaskStack 2000
-#   define TimerPollHandlerTaskStack 6000
+#   define TimerPollHandlerTaskStack 2000
+// #   define TimerPollHandlerTaskStack 6000
 #endif // def ARDUINO_ARCH_ESP32
 
 }; // c_InputFPPRemotePlayFile

--- a/ESPixelStick/src/input/InputFPPRemotePlayFile.hpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayFile.hpp
@@ -111,8 +111,8 @@ private:
 
 #ifdef ARDUINO_ARCH_ESP32
     TaskHandle_t TimerPollTaskHandle = NULL;
-#   define TimerPollHandlerTaskStack 2000
-// #   define TimerPollHandlerTaskStack 4000
+// #   define TimerPollHandlerTaskStack 2000
+#   define TimerPollHandlerTaskStack 6000
 #endif // def ARDUINO_ARCH_ESP32
 
 }; // c_InputFPPRemotePlayFile

--- a/ESPixelStick/src/input/InputFPPRemotePlayFileFsm.cpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayFileFsm.cpp
@@ -190,7 +190,7 @@ void fsm_PlayFile_state_PlayingFile::Poll ()
             if (0 != p_Parent->RemainingPlayCount)
             {
                 // DEBUG_V (String ("RemainingPlayCount: ") + String (p_Parent->RemainingPlayCount));
-                logcon (String ("Replaying:: FileName:      '") + p_Parent->GetFileName () + "'");
+                // logcon (String ("Replaying:: FileName:      '") + p_Parent->GetFileName () + "'");
                 --p_Parent->RemainingPlayCount;
                 // DEBUG_V (String ("RemainingPlayCount: ") + p_Parent->RemainingPlayCount);
 
@@ -326,7 +326,7 @@ void fsm_PlayFile_state_PlayingFile::Init (c_InputFPPRemotePlayFile* Parent)
         // DEBUG_V (String ("                  StartTimeMS: ") + String (p_Parent->StartTimeMS));
         // DEBUG_V (String ("           RemainingPlayCount: ") + p_Parent->RemainingPlayCount);
 
-        logcon (String (F ("Start Playing:: FileName: '")) + p_Parent->PlayItemName + "'");
+        // logcon (String (F ("Start Playing:: FileName: '")) + p_Parent->PlayItemName + "'");
 
         Parent->pCurrentFsmState = &(Parent->fsm_PlayFile_state_PlayingFile_imp);
         Parent->FrameControl.ElapsedPlayTimeMS = 0;
@@ -359,7 +359,7 @@ void fsm_PlayFile_state_PlayingFile::Stop (void)
 {
     // DEBUG_START;
 
-    logcon (String (F ("Stop Playing::  FileName: '")) + p_Parent->PlayItemName + "'");
+    // logcon (String (F ("Stop Playing::  FileName: '")) + p_Parent->PlayItemName + "'");
     // DEBUG_V (String ("            LastPlayedFrameId: ") + String (p_Parent->LastPlayedFrameId));
     // DEBUG_V (String ("TotalNumberOfFramesInSequence: ") + String (p_Parent->TotalNumberOfFramesInSequence));
     // DEBUG_V (String ("           RemainingPlayCount: ") + p_Parent->RemainingPlayCount);

--- a/ESPixelStick/src/input/InputFPPRemotePlayFileFsm.cpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayFileFsm.cpp
@@ -190,7 +190,7 @@ void fsm_PlayFile_state_PlayingFile::Poll ()
             if (0 != p_Parent->RemainingPlayCount)
             {
                 // DEBUG_V (String ("RemainingPlayCount: ") + String (p_Parent->RemainingPlayCount));
-                // logcon (String ("Replaying:: FileName:      '") + p_Parent->GetFileName () + "'");
+                // DEBUG_V (String ("Replaying:: FileName:      '") + p_Parent->GetFileName () + "'");
                 --p_Parent->RemainingPlayCount;
                 // DEBUG_V (String ("RemainingPlayCount: ") + p_Parent->RemainingPlayCount);
 
@@ -326,7 +326,7 @@ void fsm_PlayFile_state_PlayingFile::Init (c_InputFPPRemotePlayFile* Parent)
         // DEBUG_V (String ("                  StartTimeMS: ") + String (p_Parent->StartTimeMS));
         // DEBUG_V (String ("           RemainingPlayCount: ") + p_Parent->RemainingPlayCount);
 
-        // logcon (String (F ("Start Playing:: FileName: '")) + p_Parent->PlayItemName + "'");
+        // DEBUG_V (String (F ("Start Playing:: FileName: '")) + p_Parent->PlayItemName + "'");
 
         Parent->pCurrentFsmState = &(Parent->fsm_PlayFile_state_PlayingFile_imp);
         Parent->FrameControl.ElapsedPlayTimeMS = 0;
@@ -359,7 +359,7 @@ void fsm_PlayFile_state_PlayingFile::Stop (void)
 {
     // DEBUG_START;
 
-    // logcon (String (F ("Stop Playing::  FileName: '")) + p_Parent->PlayItemName + "'");
+    // DEBUG_V (String (F ("Stop Playing::  FileName: '")) + p_Parent->PlayItemName + "'");
     // DEBUG_V (String ("            LastPlayedFrameId: ") + String (p_Parent->LastPlayedFrameId));
     // DEBUG_V (String ("TotalNumberOfFramesInSequence: ") + String (p_Parent->TotalNumberOfFramesInSequence));
     // DEBUG_V (String ("           RemainingPlayCount: ") + p_Parent->RemainingPlayCount);

--- a/ESPixelStick/src/input/InputMgr.cpp
+++ b/ESPixelStick/src/input/InputMgr.cpp
@@ -288,9 +288,7 @@ void c_InputMgr::CreateNewConfig ()
     // Record the default configuration
     CreateJsonConfig (JsonConfig);
 
-    String ConfigData;
-    serializeJson (JsonConfigDoc, ConfigData);
-    SetConfig (ConfigData.c_str());
+    SetConfig(JsonConfigDoc);
 
     // logcon (String (F ("--- WARNING: Creating a new Input Manager configuration Data set - Done ---")));
     // DEBUG_END;
@@ -887,6 +885,33 @@ void c_InputMgr::SetConfig (const char * NewConfigData)
     else
     {
         logcon (CN_stars + String (F (" Error Saving Input Manager Config File ")) + CN_stars);
+    }
+
+    // DEBUG_END;
+
+} // SetConfig
+
+//-----------------------------------------------------------------------------
+/* Sets the configuration for the current active ports:
+ *
+ *   WARNING: This runs in the Web server context and cannot access the File system
+ */
+void c_InputMgr::SetConfig(JsonDocument & NewConfigData)
+{
+    // DEBUG_START;
+
+    if (true == FileMgr.SaveConfigFile(ConfigFileName, NewConfigData))
+    {
+        // DEBUG_V (String("NewConfigData: ") + NewConfigData);
+        // FileMgr logs for us
+        // logcon (CN_stars + String (F (" Saved Input Manager Config File. ")) + CN_stars);
+
+        configLoadNeeded = true;
+
+    } // end we saved the config
+    else
+    {
+        logcon(CN_stars + String(F(" Error Saving Input Manager Config File ")) + CN_stars);
     }
 
     // DEBUG_END;

--- a/ESPixelStick/src/input/InputMgr.hpp
+++ b/ESPixelStick/src/input/InputMgr.hpp
@@ -52,6 +52,7 @@ public:
     void GetConfig            (byte * Response, size_t maxlen);
     void GetStatus            (JsonObject & jsonStatus);
     void SetConfig            (const char * NewConfig);
+    void SetConfig            (ArduinoJson::JsonDocument & NewConfig);
     void Process              ();
     void SetBufferInfo        (uint8_t* BufferStart, uint16_t BufferSize);
     void SetOperationalState  (bool Active);

--- a/ESPixelStick/src/network/NetworkMgr.cpp
+++ b/ESPixelStick/src/network/NetworkMgr.cpp
@@ -223,13 +223,13 @@ bool c_NetworkMgr::SetConfig (JsonObject & json)
     } while (false);
 
     // DEBUG_V("");
-    HostnameChanged |= Validate();
+    HostnameChanged |= Validate ();
     // DEBUG_V("");
 
     if(HostnameChanged)
     {
         // DEBUG_V("");
-        WiFiDriver.SetHostname(hostname);
+        WiFiDriver.SetHostname (hostname);
 #ifdef SUPPORT_ETHERNET
         EthernetDriver.SetHostname (hostname);
 #endif // def SUPPORT_ETHERNET

--- a/ESPixelStick/src/network/NetworkMgr.cpp
+++ b/ESPixelStick/src/network/NetworkMgr.cpp
@@ -171,18 +171,22 @@ bool c_NetworkMgr::SetConfig (JsonObject & json)
             ConfigSaveNeeded = true;
             break;
         }
+        // DEBUG_V("");
 
         JsonObject network = json[CN_network];
 
         HostnameChanged = setFromJSON (hostname, network, CN_hostname);
+        // DEBUG_V("");
 
         if (network.containsKey (CN_wifi))
         {
+            // DEBUG_V("");
             JsonObject networkWiFi = network[CN_wifi];
             ConfigChanged |= WiFiDriver.SetConfig (networkWiFi);
         }
         else
         {
+            // DEBUG_V("");
             // this may be an old style config
             if (network.containsKey (CN_ssid))
             {
@@ -218,15 +222,19 @@ bool c_NetworkMgr::SetConfig (JsonObject & json)
 
     } while (false);
 
-    HostnameChanged |= Validate ();
+    // DEBUG_V("");
+    HostnameChanged |= Validate();
+    // DEBUG_V("");
 
     if(HostnameChanged)
     {
-        WiFiDriver.SetHostname (hostname);
+        // DEBUG_V("");
+        WiFiDriver.SetHostname(hostname);
 #ifdef SUPPORT_ETHERNET
         EthernetDriver.SetHostname (hostname);
 #endif // def SUPPORT_ETHERNET
     }
+    // DEBUG_V("");
 
     ConfigChanged |= HostnameChanged;
 
@@ -299,6 +307,7 @@ void c_NetworkMgr::SetWiFiEnable ()
         // DEBUG_V ("AllowWiFiAndEthUpSimultaneously");
         WiFiDriver.Enable ();
     }
+    // DEBUG_END;
 
 } // SetWiFiEnabled
 

--- a/ESPixelStick/src/network/WiFiDriver.cpp
+++ b/ESPixelStick/src/network/WiFiDriver.cpp
@@ -89,9 +89,9 @@ c_WiFiDriver::c_WiFiDriver ()
 ///< deallocate any resources and put the output channels into a safe state
 c_WiFiDriver::~c_WiFiDriver()
 {
- // DEBUG_START;
+    // DEBUG_START;
 
- // DEBUG_END;
+    // DEBUG_END;
 
 } // ~c_WiFiDriver
 
@@ -200,6 +200,7 @@ void c_WiFiDriver::connectWifi (const String & current_ssid, const String & curr
     // Hostname must be set after the mode on ESP8266 and before on ESP32
 #ifdef ARDUINO_ARCH_ESP8266
     WiFi.disconnect ();
+    // DEBUG_V("");
 
     // Switch to station mode
     WiFi.mode (WIFI_STA);
@@ -210,16 +211,19 @@ void c_WiFiDriver::connectWifi (const String & current_ssid, const String & curr
         // DEBUG_V (String ("Setting WiFi hostname: ") + Hostname);
         WiFi.hostname (Hostname);
     }
+    // DEBUG_V("");
 #else
     WiFi.persistent (false);
     // DEBUG_V ("");
     WiFi.disconnect (true);
+    // DEBUG_V("");
 
     if (0 != Hostname.length ())
     {
         // DEBUG_V (String ("Setting WiFi hostname: ") + Hostname);
         WiFi.hostname (Hostname);
     }
+    // DEBUG_V("");
 
     // Switch to station mode
     WiFi.mode (WIFI_STA);
@@ -234,7 +238,7 @@ void c_WiFiDriver::connectWifi (const String & current_ssid, const String & curr
                       String (F ("' as ")) +
                       Hostname);
 
- // crashes SD   WiFi.setSleep(false);
+ // TODO crashes SD   WiFi.setSleep(false);
     // DEBUG_V("");
     WiFi.begin(current_ssid.c_str(), current_passphrase.c_str());
 
@@ -246,7 +250,6 @@ void c_WiFiDriver::connectWifi (const String & current_ssid, const String & curr
 void c_WiFiDriver::Disable ()
 {
     // DEBUG_START;
-    // AnnounceState ();
 
     if (pCurrentFsmState != &fsm_WiFi_state_Disabled_imp)
     {
@@ -264,7 +267,6 @@ void c_WiFiDriver::Disable ()
 void c_WiFiDriver::Enable ()
 {
     // DEBUG_START;
-    // AnnounceState ();
 
     if (pCurrentFsmState == &fsm_WiFi_state_Disabled_imp)
     {
@@ -422,12 +424,15 @@ void c_WiFiDriver::reset ()
     // DEBUG_START;
 
     // Reset address in case we're switching from static to dhcp
-    WiFi.config (0u, 0u, 0u);
+    // Why CAM broken WiFi.config (0u, 0u, 0u);
+    // DEBUG_V("");
 
     if (IsWiFiConnected ())
     {
-        NetworkMgr.SetWiFiIsConnected (false);
+        // DEBUG_V("");
+        NetworkMgr.SetWiFiIsConnected(false);
     }
+    // DEBUG_V("");
 
     fsm_WiFi_state_Boot_imp.Init ();
 
@@ -786,11 +791,11 @@ void fsm_WiFi_state_ConnectingAsAP::Init ()
 // Wait for events
 void fsm_WiFi_state_ConnectingAsAP::OnConnect ()
 {
- // DEBUG_START;
+    // DEBUG_START;
 
     fsm_WiFi_state_ConnectedToSta_imp.Init ();
 
- // DEBUG_END;
+    // DEBUG_END;
 
 } // fsm_WiFi_state_ConnectingAsAP::OnConnect
 

--- a/ESPixelStick/src/network/WiFiDriver.cpp
+++ b/ESPixelStick/src/network/WiFiDriver.cpp
@@ -238,7 +238,7 @@ void c_WiFiDriver::connectWifi (const String & current_ssid, const String & curr
                       String (F ("' as ")) +
                       Hostname);
 
- // TODO crashes SD   WiFi.setSleep(false);
+    WiFi.setSleep(false);
     // DEBUG_V("");
     WiFi.begin(current_ssid.c_str(), current_passphrase.c_str());
 

--- a/ESPixelStick/src/network/WiFiDriver.cpp
+++ b/ESPixelStick/src/network/WiFiDriver.cpp
@@ -234,8 +234,9 @@ void c_WiFiDriver::connectWifi (const String & current_ssid, const String & curr
                       String (F ("' as ")) +
                       Hostname);
 
-    WiFi.setSleep (false);
-    WiFi.begin (current_ssid.c_str (), current_passphrase.c_str ());
+ // crashes SD   WiFi.setSleep(false);
+    // DEBUG_V("");
+    WiFi.begin(current_ssid.c_str(), current_passphrase.c_str());
 
     // DEBUG_END;
 
@@ -366,6 +367,7 @@ void c_WiFiDriver::onWiFiConnect (const WiFiEvent_t event, const WiFiEventInfo_t
 {
 #endif
     // DEBUG_START;
+
     pCurrentFsmState->OnConnect ();
 
     // DEBUG_END;
@@ -383,9 +385,9 @@ void c_WiFiDriver::onWiFiDisconnect (const WiFiEvent_t event, const WiFiEventInf
 #endif
     // DEBUG_START;
 
-    pCurrentFsmState->OnDisconnect ();
+   pCurrentFsmState->OnDisconnect ();
 
-    // DEBUG_END;
+   // DEBUG_END;
 
 } // onWiFiDisconnect
 

--- a/ESPixelStick/src/network/WiFiDriver.cpp
+++ b/ESPixelStick/src/network/WiFiDriver.cpp
@@ -223,7 +223,7 @@ void c_WiFiDriver::connectWifi (const String & current_ssid, const String & curr
         // DEBUG_V (String ("Setting WiFi hostname: ") + Hostname);
         WiFi.hostname (Hostname);
     }
-    // DEBUG_V("");
+    // DEBUG_V("Setting WiFi Mode to STA");
 
     // Switch to station mode
     WiFi.mode (WIFI_STA);
@@ -238,9 +238,9 @@ void c_WiFiDriver::connectWifi (const String & current_ssid, const String & curr
                       String (F ("' as ")) +
                       Hostname);
 
-    WiFi.setSleep(false);
+    WiFi.setSleep (false);
     // DEBUG_V("");
-    WiFi.begin(current_ssid.c_str(), current_passphrase.c_str());
+    WiFi.begin (current_ssid.c_str (), current_passphrase.c_str ());
 
     // DEBUG_END;
 
@@ -387,9 +387,9 @@ void c_WiFiDriver::onWiFiDisconnect (const WiFiEvent_t event, const WiFiEventInf
 #endif
     // DEBUG_START;
 
-   pCurrentFsmState->OnDisconnect ();
+    pCurrentFsmState->OnDisconnect ();
 
-   // DEBUG_END;
+    // DEBUG_END;
 
 } // onWiFiDisconnect
 
@@ -424,13 +424,13 @@ void c_WiFiDriver::reset ()
     // DEBUG_START;
 
     // Reset address in case we're switching from static to dhcp
-    // Why CAM broken WiFi.config (0u, 0u, 0u);
+    WiFi.config (0u, 0u, 0u);
     // DEBUG_V("");
 
     if (IsWiFiConnected ())
     {
         // DEBUG_V("");
-        NetworkMgr.SetWiFiIsConnected(false);
+        NetworkMgr.SetWiFiIsConnected (false);
     }
     // DEBUG_V("");
 
@@ -589,14 +589,14 @@ int c_WiFiDriver::ValidateConfig ()
 // Waiting for polling to start
 void fsm_WiFi_state_Boot::Poll ()
 {
-    // DEBUG_START;
+    /// DEBUG_START;
 
     // Start trying to connect to the AP
-    // DEBUG_V (String ("this: ") + String (uint32_t (this), HEX));
+    /// DEBUG_V (String ("this: ") + String (uint32_t (this), HEX));
     fsm_WiFi_state_ConnectingUsingConfig_imp.Init ();
     // pWiFiDriver->displayFsmState ();
 
-    // DEBUG_END;
+    /// DEBUG_END;
 } // fsm_WiFi_state_boot
 
 /*****************************************************************************/
@@ -620,7 +620,7 @@ void fsm_WiFi_state_Boot::Init ()
 // Wait for events
 void fsm_WiFi_state_ConnectingUsingConfig::Poll ()
 {
-    // DEBUG_START;
+    /// DEBUG_START;
 
     // wait for the connection to complete via the callback function
     uint32_t CurrentTimeMS = millis ();
@@ -629,13 +629,13 @@ void fsm_WiFi_state_ConnectingUsingConfig::Poll ()
     {
         if (CurrentTimeMS - pWiFiDriver->GetFsmStartTime() > (1000 * pWiFiDriver->Get_sta_timeout()))
         {
-            // DEBUG_V (String ("this: ") + String (uint32_t (this), HEX));
+            /// DEBUG_V (String ("this: ") + String (uint32_t (this), HEX));
             logcon (F ("WiFi Failed to connect using Configured Credentials"));
             fsm_WiFi_state_ConnectingUsingDefaults_imp.Init ();
         }
     }
 
-    // DEBUG_END;
+    /// DEBUG_END;
 } // fsm_WiFi_state_ConnectingUsingConfig::Poll
 
 /*****************************************************************************/
@@ -683,7 +683,7 @@ void fsm_WiFi_state_ConnectingUsingConfig::OnConnect ()
 // Wait for events
 void fsm_WiFi_state_ConnectingUsingDefaults::Poll ()
 {
-    // DEBUG_START;
+    /// DEBUG_START;
 
     // wait for the connection to complete via the callback function
     uint32_t CurrentTimeMS = millis ();
@@ -692,13 +692,13 @@ void fsm_WiFi_state_ConnectingUsingDefaults::Poll ()
     {
         if (CurrentTimeMS - pWiFiDriver->GetFsmStartTime () > (1000 * pWiFiDriver->Get_sta_timeout ()))
         {
-            // DEBUG_V (String ("this: ") + String (uint32_t (this), HEX));
+            /// DEBUG_V (String ("this: ") + String (uint32_t (this), HEX));
             logcon (F ("WiFi Failed to connect using default Credentials"));
             fsm_WiFi_state_ConnectingAsAP_imp.Init ();
         }
     }
 
-    // DEBUG_END;
+    /// DEBUG_END;
 } // fsm_WiFi_state_ConnectingUsingDefaults::Poll
 
 /*****************************************************************************/
@@ -736,7 +736,7 @@ void fsm_WiFi_state_ConnectingUsingDefaults::OnConnect ()
 // Wait for events
 void fsm_WiFi_state_ConnectingAsAP::Poll ()
 {
-    // DEBUG_START;
+    /// DEBUG_START;
 
     if (0 != WiFi.softAPgetStationNum ())
     {
@@ -751,7 +751,7 @@ void fsm_WiFi_state_ConnectingAsAP::Poll ()
         }
     }
 
-    // DEBUG_END;
+    /// DEBUG_END;
 } // fsm_WiFi_state_ConnectingAsAP::Poll
 
 /*****************************************************************************/
@@ -804,16 +804,16 @@ void fsm_WiFi_state_ConnectingAsAP::OnConnect ()
 // Wait for events
 void fsm_WiFi_state_ConnectedToAP::Poll ()
 {
-    // DEBUG_START;
+    /// DEBUG_START;
 
     // did we get silently disconnected?
     if (WiFi.status () != WL_CONNECTED)
     {
-     // DEBUG_V ("WiFi Handle Silent Disconnect");
+        // DEBUG_V ("WiFi Handle Silent Disconnect");
         WiFi.reconnect ();
     }
 
-    // DEBUG_END;
+    /// DEBUG_END;
 } // fsm_WiFi_state_ConnectedToAP::Poll
 
 /*****************************************************************************/
@@ -857,7 +857,7 @@ void fsm_WiFi_state_ConnectedToAP::OnDisconnect ()
 // Wait for events
 void fsm_WiFi_state_ConnectedToSta::Poll ()
 {
-   // DEBUG_START;
+    /// DEBUG_START;
 
     // did we get silently disconnected?
     if (0 == WiFi.softAPgetStationNum ())
@@ -866,7 +866,7 @@ void fsm_WiFi_state_ConnectedToSta::Poll ()
         fsm_WiFi_state_ConnectionFailed_imp.Init ();
     }
 
-    // DEBUG_END;
+    /// DEBUG_END;
 } // fsm_WiFi_state_ConnectedToSta::Poll
 
 /*****************************************************************************/

--- a/ESPixelStick/src/output/OutputCommon.cpp
+++ b/ESPixelStick/src/output/OutputCommon.cpp
@@ -253,14 +253,14 @@ void c_OutputCommon::InitializeUart (uart_config_t & uart_config,
 #endif
 
 //-----------------------------------------------------------------------------
-esp_err_t c_OutputCommon::RegisterUartIsrHandler(void (*fn)(void *), void *arg, int intr_alloc_flags)
+bool c_OutputCommon::RegisterUartIsrHandler(void (*fn)(void *), void *arg, int intr_alloc_flags)
 {
-    int ret = ESP_OK;
+    bool ret = true;
 #ifdef ARDUINO_ARCH_ESP8266
     ETS_UART_INTR_ATTACH(fn, arg);
 #else
     // UART_ENTER_CRITICAL(&(uart_context[uart_num].spinlock));
-    ret = esp_intr_alloc(uart_periph_signal[UartId].irq, intr_alloc_flags, fn, arg, nullptr);
+    ret = (ESP_OK == esp_intr_alloc(uart_periph_signal[UartId].irq, intr_alloc_flags, fn, arg, nullptr));
     // UART_EXIT_CRITICAL(&(uart_context[uart_num].spinlock));
 #endif
     return ret;

--- a/ESPixelStick/src/output/OutputCommon.cpp
+++ b/ESPixelStick/src/output/OutputCommon.cpp
@@ -35,6 +35,7 @@ extern "C" {
 #   include <soc/uart_reg.h>
 #   include <rom/ets_sys.h>
 #   include <driver/uart.h>
+#   include <soc/uart_periph.h>
 
 #   define UART_CONF0           UART_CONF0_REG
 #   define UART_CONF1           UART_CONF1_REG
@@ -250,6 +251,20 @@ void c_OutputCommon::InitializeUart (uart_config_t & uart_config,
 
 } // InitializeUart
 #endif
+
+//-----------------------------------------------------------------------------
+esp_err_t c_OutputCommon::RegisterUartIsrHandler(void (*fn)(void *), void *arg, int intr_alloc_flags)
+{
+    int ret = ESP_OK;
+#ifdef ARDUINO_ARCH_ESP8266
+    ETS_UART_INTR_ATTACH(fn, arg);
+#else
+    // UART_ENTER_CRITICAL(&(uart_context[uart_num].spinlock));
+    ret = esp_intr_alloc(uart_periph_signal[UartId].irq, intr_alloc_flags, fn, arg, nullptr);
+    // UART_EXIT_CRITICAL(&(uart_context[uart_num].spinlock));
+#endif
+    return ret;
+} // RegisterUartIsrHandler
 
 //-----------------------------------------------------------------------------
 void c_OutputCommon::GetStatus (JsonObject & jsonStatus)

--- a/ESPixelStick/src/output/OutputCommon.hpp
+++ b/ESPixelStick/src/output/OutputCommon.hpp
@@ -90,6 +90,7 @@ protected:
     void StartBreak ();
     void EndBreak ();
     void GenerateBreak (uint32_t DurationInUs);
+    esp_err_t RegisterUartIsrHandler(void (*fn)(void *), void *arg, int intr_alloc_flags);
 
     inline bool canRefresh ()
     {

--- a/ESPixelStick/src/output/OutputCommon.hpp
+++ b/ESPixelStick/src/output/OutputCommon.hpp
@@ -90,7 +90,12 @@ protected:
     void StartBreak ();
     void EndBreak ();
     void GenerateBreak (uint32_t DurationInUs);
-    esp_err_t RegisterUartIsrHandler(void (*fn)(void *), void *arg, int intr_alloc_flags);
+
+#ifndef ESP_INTR_FLAG_IRAM
+#   define ESP_INTR_FLAG_IRAM 0
+#endif // ndef ESP_INTR_FLAG_IRAM
+
+    bool RegisterUartIsrHandler(void (*fn)(void *), void *arg, int intr_alloc_flags);
 
     inline bool canRefresh ()
     {

--- a/ESPixelStick/src/output/OutputGS8208Uart.cpp
+++ b/ESPixelStick/src/output/OutputGS8208Uart.cpp
@@ -146,11 +146,7 @@ void c_OutputGS8208Uart::Begin ()
 #endif
 
     // Atttach interrupt handler
-#ifdef ARDUINO_ARCH_ESP8266
-    ETS_UART_INTR_ATTACH (uart_intr_handler, this);
-#else
-    uart_isr_register (UartId, uart_intr_handler, this, UART_TXFIFO_EMPTY_INT_ENA | ESP_INTR_FLAG_IRAM, nullptr);
-#endif
+    RegisterUartIsrHandler(uart_intr_handler, this, UART_TXFIFO_EMPTY_INT_ENA | ESP_INTR_FLAG_IRAM);
 
     // invert the output
     CLEAR_PERI_REG_MASK (UART_CONF0 (UartId), UART_INV_MASK);

--- a/ESPixelStick/src/output/OutputMgr.hpp
+++ b/ESPixelStick/src/output/OutputMgr.hpp
@@ -122,12 +122,19 @@ public:
     };
 
 #ifdef ARDUINO_ARCH_ESP8266
-#   define OM_MAX_NUM_CHANNELS  (1200 * 3)
-#else
-#   define OM_MAX_NUM_CHANNELS  (3000 * 3)
-#endif // !def ARDUINO_ARCH_ESP8266
+#   define OM_MAX_NUM_CHANNELS      (1200 * 3)
+#   define OM_MAX_CONFIG_SIZE       ((size_t)(5 * 1024))
+#else // ARDUINO_ARCH_ESP32
+#   ifdef BOARD_HAS_PSRAM
+#       define OM_MAX_NUM_CHANNELS  (7000 * 3)
+#       define OM_MAX_CONFIG_SIZE   ((size_t)(20 * 1024))
+#   else
+#       define OM_MAX_NUM_CHANNELS  (3000 * 3)
+#       define OM_MAX_CONFIG_SIZE   ((size_t)(11 * 1024))
+#   endif // !def BOARD_HAS_PSRAM
+#endif // !def ARDUINO_ARCH_ESP32
 
-private:
+    private:
 
     void InstantiateNewOutputChannel (e_OutputChannelIds ChannelIndex, e_OutputType NewChannelType, bool StartDriver = true);
     void CreateNewConfig ();
@@ -136,12 +143,6 @@ private:
     c_OutputCommon * pOutputChannelDrivers[uint32_t(e_OutputChannelIds::OutputChannelId_End)];
 
     // configuration parameter names for the channel manager within the config file
-
-#ifdef ARDUINO_ARCH_ESP8266
-#   define OM_MAX_CONFIG_SIZE      ((size_t)(5*1024))
-#else
-#   define OM_MAX_CONFIG_SIZE      ((size_t)(11*1024))
-#endif // !def ARDUINO_ARCH_ESP8266
 
     bool HasBeenInitialized = false;
     bool ConfigLoadNeeded   = false;

--- a/ESPixelStick/src/output/OutputMgr.hpp
+++ b/ESPixelStick/src/output/OutputMgr.hpp
@@ -41,6 +41,7 @@ public:
     void      GetConfig         (byte * Response, size_t maxlen);
     void      GetConfig         (String & Response);
     void      SetConfig         (const char * NewConfig);  ///< Save the current configuration data to nvram
+    void      SetConfig         (ArduinoJson::JsonDocument & NewConfig);  ///< Save the current configuration data to nvram
     void      GetStatus         (JsonObject & jsonStatus);
     void      PauseOutput       (bool PauseTheOutput) { IsOutputPaused = PauseTheOutput; }
     void      GetPortCounts     (uint16_t& PixelCount, uint16_t& SerialCount) {PixelCount = uint16_t(OutputChannelId_End); SerialCount = min(uint16_t(OutputChannelId_End), uint16_t(2)); }
@@ -139,7 +140,7 @@ private:
 #ifdef ARDUINO_ARCH_ESP8266
 #   define OM_MAX_CONFIG_SIZE      ((size_t)(5*1024))
 #else
-#   define OM_MAX_CONFIG_SIZE      ((size_t)(10*1024))
+#   define OM_MAX_CONFIG_SIZE      ((size_t)(11*1024))
 #endif // !def ARDUINO_ARCH_ESP8266
 
     bool HasBeenInitialized = false;

--- a/ESPixelStick/src/output/OutputSerial.cpp
+++ b/ESPixelStick/src/output/OutputSerial.cpp
@@ -160,11 +160,7 @@ void c_OutputSerial::StartUart ()
     RemainingDataCount = 0;
 
     // Atttach interrupt handler
-#ifdef ARDUINO_ARCH_ESP8266
-    ETS_UART_INTR_ATTACH (uart_intr_handler, this);
-#else
-    uart_isr_register (UartId, uart_intr_handler, this, UART_TXFIFO_EMPTY_INT_ENA | ESP_INTR_FLAG_IRAM, nullptr);
-#endif
+    RegisterUartIsrHandler(uart_intr_handler, this, UART_TXFIFO_EMPTY_INT_ENA | ESP_INTR_FLAG_IRAM);
 
     enqueue (0xff);
 

--- a/ESPixelStick/src/output/OutputTM1814Uart.cpp
+++ b/ESPixelStick/src/output/OutputTM1814Uart.cpp
@@ -131,11 +131,7 @@ void c_OutputTM1814Uart::Begin ()
     // DEBUG_V (String ("TM1814_BAUD_RATE: ") + String (TM1814_BAUD_RATE));
 
     // Atttach interrupt handler
-#ifdef ARDUINO_ARCH_ESP8266
-    ETS_UART_INTR_ATTACH (uart_intr_handler, this);
-#else
-    uart_isr_register (UartId, uart_intr_handler, this, UART_TXFIFO_EMPTY_INT_ENA | ESP_INTR_FLAG_IRAM, nullptr);
-#endif
+    RegisterUartIsrHandler(uart_intr_handler, this, UART_TXFIFO_EMPTY_INT_ENA | ESP_INTR_FLAG_IRAM);
 
 } // init
 

--- a/ESPixelStick/src/output/OutputUCS1903Uart.cpp
+++ b/ESPixelStick/src/output/OutputUCS1903Uart.cpp
@@ -140,11 +140,7 @@ void c_OutputUCS1903Uart::Begin ()
 #endif
 
     // Atttach interrupt handler
-#ifdef ARDUINO_ARCH_ESP8266
-    ETS_UART_INTR_ATTACH (uart_intr_handler, this);
-#else
-    uart_isr_register (UartId, uart_intr_handler, this, UART_TXFIFO_EMPTY_INT_ENA | ESP_INTR_FLAG_IRAM, nullptr);
-#endif
+    RegisterUartIsrHandler(uart_intr_handler, this, UART_TXFIFO_EMPTY_INT_ENA | ESP_INTR_FLAG_IRAM);
 
     // invert the output
     CLEAR_PERI_REG_MASK (UART_CONF0 (UartId), UART_INV_MASK);

--- a/ESPixelStick/src/output/OutputWS2811Uart.cpp
+++ b/ESPixelStick/src/output/OutputWS2811Uart.cpp
@@ -139,11 +139,7 @@ void c_OutputWS2811Uart::Begin ()
 #endif
 
     // Atttach interrupt handler
-#ifdef ARDUINO_ARCH_ESP8266
-    ETS_UART_INTR_ATTACH (uart_intr_handler, this);
-#else
-    uart_isr_register (UartId, uart_intr_handler, this, UART_TXFIFO_EMPTY_INT_ENA | ESP_INTR_FLAG_IRAM, nullptr);
-#endif
+    RegisterUartIsrHandler(uart_intr_handler, this, UART_TXFIFO_EMPTY_INT_ENA | ESP_INTR_FLAG_IRAM);
 
     // invert the output
     CLEAR_PERI_REG_MASK (UART_CONF0 (UartId), UART_INV_MASK);

--- a/html/script.js
+++ b/html/script.js
@@ -826,9 +826,9 @@ function ProcessReceivedJsonConfigMessage(JsonConfigData)
     else if ({}.hasOwnProperty.call(JsonConfigData, "system"))
     {
         System_Config = JsonConfigData.system;
-        console.info("Got System Config: " + System_Config);
+        // console.info("Got System Config: " + System_Config);
 
-        updateFromJSON(JsonConfigData.system);
+        updateFromJSON(System_Config);
 
         if ({}.hasOwnProperty.call(System_Config.network, 'eth')) {
             $('#pg_network #network #eth').removeClass("hidden")
@@ -1036,7 +1036,6 @@ function ExtractNetworkEthernetConfigFromHtmlPage()
         System_Config.network.eth.netmask     = $('#network #eth #netmask').val();
         System_Config.network.eth.gateway     = $('#network #eth #gateway').val();
         System_Config.network.eth.dhcp        = $('#network #eth #dhcp').prop('checked');
-        System_Config.network.eth.type        = $('#network #eth #type').val();
         System_Config.network.eth.type        = parseInt($('#network #eth #type option:selected').val(), 10);
         System_Config.network.eth.addr        = $('#network #eth #addr').val();
         System_Config.network.eth.power_pin   = $('#network #eth #power_pin').val();
@@ -1060,9 +1059,19 @@ function ExtractNetworkConfigFromHtmlPage()
 } // ExtractNetworkConfigFromHtmlPage
 
 // Builds JSON config submission for "WiFi" tab
-function submitNetworkConfig() {
+function submitNetworkConfig()
+{
+    System_Config.device.id        = $('#config #device #id').val();
+    System_Config.device.blanktime = $('#config #device #blanktime').val();
+    System_Config.device.miso_pin  = $('#config #device #miso_pin').val();
+    System_Config.device.mosi_pin  = $('#config #device #mosi_pin').val();
+    System_Config.device.clock_pin = $('#config #device #clock_pin').val();
+    System_Config.device.cs_pin    = $('#config #device #cs_pin').val();
+
     ExtractNetworkConfigFromHtmlPage();
-    wsEnqueue(JSON.stringify({ 'cmd': { 'set': System_Config } }));
+
+    // console.info("Send: " + JSON.stringify({ 'cmd': { 'set': { 'system': System_Config } } }));
+    wsEnqueue(JSON.stringify({ 'cmd': { 'set': { 'system': System_Config }}}));
 
 } // submitNetworkConfig
 
@@ -1171,15 +1180,8 @@ function submitDeviceConfig()
 
     ExtractChannelConfigFromHtmlPage(Output_Config.channels, "output");
 
-    System_Config.device.id        = $('#config #device #id').val();
-    System_Config.device.blanktime = $('#config #device #blanktime').val();
-    System_Config.device.miso_pin  = $('#config #device #miso_pin').val();
-    System_Config.device.mosi_pin  = $('#config #device #mosi_pin').val();
-    System_Config.device.clock_pin = $('#config #device #clock_pin').val();
-    System_Config.device.cs_pin    = $('#config #device #cs_pin').val();
-
-    wsEnqueue(JSON.stringify({ 'cmd': { 'set': System_Config } }));
-    wsEnqueue(JSON.stringify({ 'cmd': { 'set': { 'input':  { 'input_config': Input_Config } } } }));
+    submitNetworkConfig();
+    wsEnqueue(JSON.stringify({ 'cmd': { 'set': { 'input':  { 'input_config':  Input_Config  } } } }));
     wsEnqueue(JSON.stringify({ 'cmd': { 'set': { 'output': { 'output_config': Output_Config } } } }));
 
 } // submitDeviceConfig

--- a/html/script.js
+++ b/html/script.js
@@ -823,11 +823,12 @@ function ProcessReceivedJsonConfigMessage(JsonConfigData)
     }
 
     // is this a device config?
-    else if ({}.hasOwnProperty.call(JsonConfigData, "device"))
+    else if ({}.hasOwnProperty.call(JsonConfigData, "system"))
     {
-        // console.info("Got Device Config");
-        System_Config = JsonConfigData;
-        updateFromJSON(JsonConfigData);
+        System_Config = JsonConfigData.system;
+        console.info("Got System Config: " + System_Config);
+
+        updateFromJSON(JsonConfigData.system);
 
         if ({}.hasOwnProperty.call(System_Config.network, 'eth')) {
             $('#pg_network #network #eth').removeClass("hidden")

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,12 +4,13 @@
 ; Local configuration should be done in platformio_user.ini
 
 [platformio]
-default_envs = espsv3, d1_mini, d32_pro, d32_pro_eth, esp32_cam, esp32_ttgo_t8, d1_mini32, d1_mini32_eth, d1_mini_mhetesp32minikit
+default_envs = espsv3, d1_mini, d32_pro, d32_pro_eth, esp32_cam, esp32_ttgo_t8, d1_mini32, d1_mini32_eth, esp32_wt32eth01
 src_dir = ./ESPixelStick
 data_dir = ./ESPixelStick/data
-build_cache_dir = ~/.buildcache
-extra_configs =
-    platformio_user.ini
+build_cache_dir = ./.pio/buildcache
+packages_dir = ./.pio/packages
+cache_dir = ./.pio/cache
+extra_configs = platformio_user.ini
 
 ;~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~;
 ; Baseline build environment                                         ;
@@ -22,12 +23,12 @@ upload_speed = 921600
 lib_compat_mode = strict
 lib_deps =
     adafruit/Adafruit PWM Servo Driver Library @ 2.4.0
-    bblanchon/ArduinoJson @ 6.18.4
-    bblanchon/StreamUtils @ 1.6.1
+    bblanchon/ArduinoJson @ 6.19.2
+    bblanchon/StreamUtils @ 1.6.2
     djgrrr/Int64String @ 1.1.1
     https://github.com/forkineye/ESPAsyncWebServer.git#v2.0.0
     forkineye/ESPAsyncE131 @ 1.0.4
-    ottowinter/AsyncMqttClient-esphome @ 0.8.5
+    ottowinter/AsyncMqttClient-esphome @ 0.8.6
     https://github.com/natcl/Artnet                         ; pull latest
     https://github.com/MartinMueller2003/Espalexa           ; pull latest
 lib_ignore =
@@ -35,6 +36,9 @@ lib_ignore =
 extra_scripts =
     pre:.scripts/pio-version.py
     .scripts/download_fs.py
+; build_type = debug
+upload_port = 
+     com6    
 
 ;~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~;
 ; ESP8266 defaults for 4MB flash                                     ;
@@ -72,6 +76,7 @@ platform = espressif32
 board_build.filesystem = littlefs
 board_build.partitions = ESP32_partitions.csv
 monitor_filters = esp32_exception_decoder
+
 build_flags =
     ${env.build_flags}
 lib_deps =
@@ -85,9 +90,14 @@ extra_scripts = .scripts/replace_fs.py
 ;~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~;
 [esp32git]
 extends = esp32
-platform  = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
-platform_packages =
-   framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.0
+platform = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
+platform_packages = 
+    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#4da1051266c2d664846f9eb7bc0d8936cb4b0848 ; Master @ March 3 2022
+;    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#78b2df74f5cd9bcdc67cec884e0c25b2ec8ffc5e ; Jan 18 New IDF Breaks UART
+;    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#77756d8a06e869875438e34ca6056738f98e5938 ; Jan 17 - Fast Good.
+;    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.2 ; runs real slow
+;    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.1 ; Has general issues
+;    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.0 ; SD card not stable on cam card
 
 ;~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~;
 ; Build targets (environments) ;
@@ -121,20 +131,20 @@ build_flags =
 extends = esp32git
 board = lolin_d32_pro
 build_flags =
+    -DBOARD_ESP32_LOLIN_D32_PRO
     -DBOARD_HAS_PSRAM
     -mfix-esp32-psram-cache-issue
     -mfix-esp32-psram-cache-strategy=memw
-    -DBOARD_ESP32_LOLIN_D32_PRO
 
 ; Lolin D32 Pro with Ethernet
 [env:d32_pro_eth]
 extends = esp32git
 board = lolin_d32_pro
 build_flags =
+    -DBOARD_ESP32_LOLIN_D32_PRO_ETH
     -DBOARD_HAS_PSRAM
     -mfix-esp32-psram-cache-issue
     -mfix-esp32-psram-cache-strategy=memw
-    -DBOARD_ESP32_LOLIN_D32_PRO_ETH
 
 ; ESP32 CAM
 [env:esp32_cam]
@@ -144,16 +154,21 @@ monitor_rts = 0
 monitor_dtr = 0
 build_flags =
     -DBOARD_ESP32_CAM
+;    -DBOARD_HAS_PSRAM
+;    -mfix-esp32-psram-cache-issue
+;    -mfix-esp32-psram-cache-strategy=memw
 
 ; ESP32 TTGO-T8 V1.x
 [env:esp32_ttgo_t8]
 extends = esp32git
-board = wemos_d1_mini32 ; use until platformio adds TTGO-T8
+board = ttgo-t7-v14-mini32 ; use until platformio adds TTGO-T8
 monitor_rts = 0
 monitor_dtr = 0
 build_flags =
     -DBOARD_ESP32_TTGO_T8
     -DBOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+    -mfix-esp32-psram-cache-strategy=memw
 
 ; Generic Wemos D1 Mini 32
 [env:d1_mini32]
@@ -162,6 +177,8 @@ board = wemos_d1_mini32
 build_flags =
     -DBOARD_ESP32_D1_MINI
     -DBOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+    -mfix-esp32-psram-cache-strategy=memw
 
 ; Generic Wemos D1 Mini 32
 [env:d1_mini32_eth]
@@ -170,10 +187,15 @@ board = wemos_d1_mini32
 build_flags =
     -DBOARD_ESP32_D1_MINI_ETH
     -DBOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+    -mfix-esp32-psram-cache-strategy=memw
 
-; MH ET LIVE MiniKit
-[env:d1_mini_mhetesp32minikit]
+; WT 32 ETH 01
+[env:esp32_wt32eth01]
 extends = esp32git
-board = mhetesp32minikit
+board = esp32doit-devkit-v1
 build_flags =
-    -DBOARD_ESP32_MH_ET_LIVE_MiniKit
+    -DBOARD_ESP32_WT32ETH01
+    -DBOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+    -mfix-esp32-psram-cache-strategy=memw

--- a/platformio.ini
+++ b/platformio.ini
@@ -35,8 +35,6 @@ lib_ignore =
 extra_scripts =
     pre:.scripts/pio-version.py
     .scripts/download_fs.py
-upload_port = 
-    com6    
 
 ;~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~;
 ; ESP8266 defaults for 4MB flash                                     ;
@@ -155,6 +153,7 @@ monitor_rts = 0
 monitor_dtr = 0
 build_flags =
     -DBOARD_ESP32_TTGO_T8
+    -DBOARD_HAS_PSRAM
 
 ; Generic Wemos D1 Mini 32
 [env:d1_mini32]
@@ -162,6 +161,7 @@ extends = esp32git
 board = wemos_d1_mini32
 build_flags =
     -DBOARD_ESP32_D1_MINI
+    -DBOARD_HAS_PSRAM
 
 ; Generic Wemos D1 Mini 32
 [env:d1_mini32_eth]
@@ -169,6 +169,7 @@ extends = esp32git
 board = wemos_d1_mini32
 build_flags =
     -DBOARD_ESP32_D1_MINI_ETH
+    -DBOARD_HAS_PSRAM
 
 ; MH ET LIVE MiniKit
 [env:d1_mini_mhetesp32minikit]

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,9 +7,9 @@
 default_envs = espsv3, d1_mini, d32_pro, d32_pro_eth, esp32_cam, esp32_ttgo_t8, d1_mini32, d1_mini32_eth, esp32_wt32eth01
 src_dir = ./ESPixelStick
 data_dir = ./ESPixelStick/data
-build_cache_dir = ./.pio/buildcache
-packages_dir = ./.pio/packages
-cache_dir = ./.pio/cache
+build_cache_dir = ~/.buildcache
+; packages_dir = ./.pio/packages
+; cache_dir = ./.pio/cache
 extra_configs = platformio_user.ini
 
 ;~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~;
@@ -37,8 +37,7 @@ extra_scripts =
     pre:.scripts/pio-version.py
     .scripts/download_fs.py
 ; build_type = debug
-upload_port = 
-     com6    
+upload_port = com6    
 
 ;~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~;
 ; ESP8266 defaults for 4MB flash                                     ;

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@
 ; Local configuration should be done in platformio_user.ini
 
 [platformio]
-default_envs = espsv3, d1_mini, d32_pro, d32_pro_eth, esp32_cam, esp32_ttgo_t8, d1_mini32, d1_mini32_eth, esp32_wt32eth01, QuinLED_ESP32
+default_envs = espsv3, d1_mini, d32_pro, d32_pro_eth, esp32_cam, esp32_ttgo_t8, d1_mini32, d1_mini32_eth, esp32_wt32eth01, esp32_quinled_quad, esp32_quinled_quad_eth, esp32_quinled_uno, esp32_quinled_uno_eth
 src_dir = ./ESPixelStick
 data_dir = ./ESPixelStick/data
 build_cache_dir = ~/.buildcache
@@ -200,11 +200,38 @@ build_flags =
     -mfix-esp32-psram-cache-issue
     -mfix-esp32-psram-cache-strategy=memw
 
-[env:QuinLED_ESP32]
+[env:esp32_quinled_quad]
 extends = esp32git
 board = wemos_d1_mini32
 build_flags =
-    -DBOARD_ESP32_QUINLED_ETH
+    -DBOARD_ESP32_QUINLED_QUAD
+    -DBOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+    -mfix-esp32-psram-cache-strategy=memw
+
+[env:esp32_quinled_quad_eth]
+extends = esp32git
+board = wemos_d1_mini32
+build_flags =
+    -DBOARD_ESP32_QUINLED_QUAD_ETH
+    -DBOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+    -mfix-esp32-psram-cache-strategy=memw
+
+[env:esp32_quinled_uno]
+extends = esp32git
+board = wemos_d1_mini32
+build_flags =
+    -DBOARD_ESP32_QUINLED_UNO
+    -DBOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+    -mfix-esp32-psram-cache-strategy=memw
+
+[env:esp32_quinled_uno_eth]
+extends = esp32git
+board = wemos_d1_mini32
+build_flags =
+    -DBOARD_ESP32_QUINLED_UNO_ETH
     -DBOARD_HAS_PSRAM
     -mfix-esp32-psram-cache-issue
     -mfix-esp32-psram-cache-strategy=memw

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@
 ; Local configuration should be done in platformio_user.ini
 
 [platformio]
-default_envs = espsv3, d1_mini, d32_pro, d32_pro_eth, esp32_cam, esp32_ttgo_t8, d1_mini32, d1_mini32_eth, esp32_wt32eth01
+default_envs = espsv3, d1_mini, d32_pro, d32_pro_eth, esp32_cam, esp32_ttgo_t8, d1_mini32, d1_mini32_eth, esp32_wt32eth01, QuinLED_ESP32
 src_dir = ./ESPixelStick
 data_dir = ./ESPixelStick/data
 build_cache_dir = ~/.buildcache
@@ -196,6 +196,15 @@ extends = esp32git
 board = esp32doit-devkit-v1
 build_flags =
     -DBOARD_ESP32_WT32ETH01
+    -DBOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+    -mfix-esp32-psram-cache-strategy=memw
+
+[env:QuinLED_ESP32]
+extends = esp32git
+board = wemos_d1_mini32
+build_flags =
+    -DBOARD_ESP32_QUINLED_ETH
     -DBOARD_HAS_PSRAM
     -mfix-esp32-psram-cache-issue
     -mfix-esp32-psram-cache-strategy=memw

--- a/platformio.ini
+++ b/platformio.ini
@@ -91,6 +91,7 @@ extra_scripts = .scripts/replace_fs.py
 extends = esp32
 platform = https://github.com/platformio/platform-espressif32.git#feature/arduino-idf-master
 platform_packages = 
+;    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#master
     framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#4da1051266c2d664846f9eb7bc0d8936cb4b0848 ; Master @ March 3 2022
 ;    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#78b2df74f5cd9bcdc67cec884e0c25b2ec8ffc5e ; Jan 18 New IDF Breaks UART
 ;    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#77756d8a06e869875438e34ca6056738f98e5938 ; Jan 17 - Fast Good.
@@ -153,9 +154,9 @@ monitor_rts = 0
 monitor_dtr = 0
 build_flags =
     -DBOARD_ESP32_CAM
-;    -DBOARD_HAS_PSRAM
-;    -mfix-esp32-psram-cache-issue
-;    -mfix-esp32-psram-cache-strategy=memw
+    -DBOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+    -mfix-esp32-psram-cache-strategy=memw
 
 ; ESP32 TTGO-T8 V1.x
 [env:esp32_ttgo_t8]


### PR DESCRIPTION
1. Added support for PSRAM. Moved Web Buffers and json structures into PSRAM. This allowed an increase in number of pixels supported when PSRAM is present from 3000 pixels to 7000 pixels.
3. Added new board type esp32_wt32eth01 (not tested)
4. Changes to work around latest changes in uart.c that cause crashes.
5. Updated the ESP Framework version to the March 3 2022 version to get fixes to SD MMD and performance improvements.
6. Updated other libs to latest versions
7. WARNING: Arduino IDE can no longer be used to build and load the images for ESP32 builds. 
8. Added QuinLED board definitions. Not part of build yet.