### PR TITLE
QuinLED Quad outputs update

### DIFF
--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD.hpp
@@ -24,7 +24,8 @@
 #define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_3
 #define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_1
 #define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_4
-#define RMT_LAST                OutputChannelId_RMT_4
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_15 // Q1R output can be used for pixels
+#define RMT_LAST                OutputChannelId_RMT_5
 
 #define DEFAULT_I2C_SDA gpio_num_t::GPIO_NUM_21
 #define DEFAULT_I2C_SCL gpio_num_t::GPIO_NUM_22

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD.hpp
@@ -50,5 +50,5 @@
 #define SUPPORT_OutputType_UCS8903          // UART / RMT
 // #define SUPPORT_OutputType_WS2801           // SPI
 #define SUPPORT_OutputType_WS2811           // UART / RMT
-#define SUPPORT_OutputType_Relay            // GPIO
+// #define SUPPORT_OutputType_Relay            // GPIO
 // #define SUPPORT_OutputType_Servo_PCA9685    // I2C (default pins)

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD.hpp
@@ -50,5 +50,5 @@
 #define SUPPORT_OutputType_UCS8903          // UART / RMT
 // #define SUPPORT_OutputType_WS2801           // SPI
 #define SUPPORT_OutputType_WS2811           // UART / RMT
-// #define SUPPORT_OutputType_Relay            // GPIO
+#define SUPPORT_OutputType_Relay            // GPIO
 // #define SUPPORT_OutputType_Servo_PCA9685    // I2C (default pins)

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD_ETH.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD_ETH.hpp
@@ -26,7 +26,8 @@
 #define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_3
 #define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_1
 #define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_4
-#define RMT_LAST                OutputChannelId_RMT_4
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_15 // Q1R output can be used for pixels
+#define RMT_LAST                OutputChannelId_RMT_5
 
 #define DEFAULT_I2C_SDA         gpio_num_t::GPIO_NUM_21
 #define DEFAULT_I2C_SCL         gpio_num_t::GPIO_NUM_22

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD_ETH.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD_ETH.hpp
@@ -84,5 +84,5 @@
 #define SUPPORT_OutputType_UCS8903        // UART / RMT
 // #define SUPPORT_OutputType_WS2801         // SPI
 #define SUPPORT_OutputType_WS2811         // UART / RMT
-// #define SUPPORT_OutputType_Relay          // GPIO
+#define SUPPORT_OutputType_Relay          // GPIO
 // #define SUPPORT_OutputType_Servo_PCA9685  // I2C (default pins)

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD_ETH.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD_ETH.hpp
@@ -84,5 +84,5 @@
 #define SUPPORT_OutputType_UCS8903        // UART / RMT
 // #define SUPPORT_OutputType_WS2801         // SPI
 #define SUPPORT_OutputType_WS2811         // UART / RMT
-#define SUPPORT_OutputType_Relay          // GPIO
+// #define SUPPORT_OutputType_Relay          // GPIO
 // #define SUPPORT_OutputType_Servo_PCA9685  // I2C (default pins)

--- a/dist/firmware/firmware.json
+++ b/dist/firmware/firmware.json
@@ -327,6 +327,76 @@
                 "size": "0x50000",
                 "offset": "0x3B0000"
             }
+        },
+        {
+            "name": "QuinLED-Dig-Quad",
+            "description": "QuinLED-Dig-Quad (pre-assembled v3r1)",
+            "chip": "esp32",
+            "appbin": "esp32/esp32_quinled_quad-app.bin",
+            "esptool": {
+                "baudrate": "460800",
+                "options": "--before default_reset --after hard_reset",
+                "flashcmd": "write_flash -z"
+            },
+            "binfiles": [
+                {
+                    "name": "esp32/esp32_quinled_quad-bootloader.bin",
+                    "offset": "0x1000"
+                },
+                {
+                    "name": "esp32/esp32_quinled_quad-partitions.bin",
+                    "offset": "0x8000"
+                },
+                {
+                    "name": "esp32/boot_app0.bin",
+                    "offset": "0xe000"
+                },
+                {
+                    "name": "esp32/esp32_quinled_quad-app.bin",
+                    "offset": "0x10000"
+                }
+            ],
+            "filesystem": {
+                "page": "256",
+                "block": "4096",
+                "size": "0x50000",
+                "offset": "0x3B0000"
+            }
+        },
+        {
+            "name": "QuinLED-Dig-Quad ETH",
+            "description": "QuinLED-Dig-Quad with Ethernet (pre-assembled v3r1)",
+            "chip": "esp32",
+            "appbin": "esp32/esp32_quinled_quad_eth-app.bin",
+            "esptool": {
+                "baudrate": "460800",
+                "options": "--before default_reset --after hard_reset",
+                "flashcmd": "write_flash -z"
+            },
+            "binfiles": [
+                {
+                    "name": "esp32/esp32_quinled_quad_eth-bootloader.bin",
+                    "offset": "0x1000"
+                },
+                {
+                    "name": "esp32/esp32_quinled_quad_eth-partitions.bin",
+                    "offset": "0x8000"
+                },
+                {
+                    "name": "esp32/boot_app0.bin",
+                    "offset": "0xe000"
+                },
+                {
+                    "name": "esp32/esp32_quinled_quad_eth-app.bin",
+                    "offset": "0x10000"
+                }
+            ],
+            "filesystem": {
+                "page": "256",
+                "block": "4096",
+                "size": "0x50000",
+                "offset": "0x3B0000"
+            }
         }
     ]
 }


### PR DESCRIPTION
Resolves #510

Secret: QuinLED Quad is actually a **_five_**-output controller!  Q1R uses same hardware as other four pixel outputs.

This board also supports driving of a relay via Q1R (GPIO15).