### PR TITLE
Security fixes, build-break fix, and best-practices fixes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,11 +80,6 @@ jobs:
         run: |
           echo "${GITHUB_REF#refs/*/v}" > firmware/VERSION
 
-      - name: Create secrets.h
-        run: |
-          echo '#define SECRETS_SSID "SSID_NOT_SET"' > ESPixelStick/src/network/secrets.h
-          echo '#define SECRETS_PASS "PASSPHRASE_NOT_SET"' >> ESPixelStick/src/network/secrets.h
-
       - name: Cache pip
         uses: actions/cache@v2
         with:

--- a/ESPixelStick/secrets.h
+++ b/ESPixelStick/secrets.h
@@ -1,0 +1,22 @@
+/*
+* secrets.h - file created to avoid build break
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2021, 2022 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*/
+
+// #define SECRETS_SSID "DEFAULT_SSID_NOT_SET"
+// #define SECRETS_PASS "DEFAULT_PASSPHRASE_NOT_SET"
+

--- a/ESPixelStick/src/input/InputFPPRemotePlayFile.cpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayFile.cpp
@@ -203,7 +203,7 @@ void c_InputFPPRemotePlayFile::GetStatus (JsonObject& JsonStatus)
     int minRem = secsTot / 60;
     secsTot = secsTot % 60;
 
-    char buf[8];
+    char buf[12]; // avoid -Wformat-overflow= warning by increasing size from 6 to 12
     sprintf (buf, "%02d:%02d", mins, secs);
     JsonStatus[CN_time_elapsed] = buf;
 

--- a/ESPixelStick/src/input/externalInput.cpp
+++ b/ESPixelStick/src/input/externalInput.cpp
@@ -25,7 +25,7 @@ fsm_ExternalInput_wait_for_off_state  fsm_ExternalInput_wait_for_off_state_imp;
 c_ExternalInput::c_ExternalInput(void)
 {
 	// DEBUG_START;
-	fsm_ExternalInput_boot_imp.Init (this);
+	fsm_ExternalInput_boot_imp.Init(*this);
 	// DEBUG_END;
 
 } // c_ExternalInput
@@ -137,7 +137,7 @@ void c_ExternalInput::ProcessConfig (JsonObject JsonData)
 		pinMode (m_iPinId, INPUT);
 		m_bHadLongPush  = false;
 		m_bHadShortPush = false;
-		fsm_ExternalInput_boot_imp.Init (this);
+		fsm_ExternalInput_boot_imp.Init (*this);
 	}
 
 	// DEBUG_V (String ("m_iPinId: ") + String (m_iPinId));
@@ -158,7 +158,7 @@ void c_ExternalInput::ProcessConfig (JsonObject JsonData)
 void c_ExternalInput::Poll (void)
 {
 	// DEBUG_START;
-	m_pCurrentFsmState->Poll (this);
+	m_pCurrentFsmState->Poll (*this);
 
 	// DEBUG_END;
 
@@ -197,9 +197,9 @@ bool c_ExternalInput::ReadInput (void)
 
 /*****************************************************************************/
 // waiting for the system to come up
-void fsm_ExternalInput_boot::Init (c_ExternalInput* pExternalInput)
+void fsm_ExternalInput_boot::Init (c_ExternalInput& pExternalInput)
 {
-	pExternalInput->m_pCurrentFsmState = &fsm_ExternalInput_boot_imp;
+	pExternalInput.m_pCurrentFsmState = &fsm_ExternalInput_boot_imp;
 
 	// dont do anything
 
@@ -207,10 +207,10 @@ void fsm_ExternalInput_boot::Init (c_ExternalInput* pExternalInput)
 
 /*****************************************************************************/
 // waiting for the system to come up
-void fsm_ExternalInput_boot::Poll (c_ExternalInput* pExternalInput)
+void fsm_ExternalInput_boot::Poll (c_ExternalInput& pExternalInput)
 {
 	// start normal operation
-	if (pExternalInput->m_bIsEnabled)
+	if (pExternalInput.m_bIsEnabled)
 	{
 		fsm_ExternalInput_off_state_imp.Init (pExternalInput);
 	}
@@ -221,30 +221,30 @@ void fsm_ExternalInput_boot::Poll (c_ExternalInput* pExternalInput)
 /*****************************************************************************/
 /*****************************************************************************/
 // Input is off and is stable
-void fsm_ExternalInput_off_state::Init(c_ExternalInput* pExternalInput)
+void fsm_ExternalInput_off_state::Init(c_ExternalInput& pExternalInput)
 {
 	// DEBUG_START;
 
-	pExternalInput->m_iInputDebounceCount = MIN_INPUT_STABLE_VALUE;
-	pExternalInput->m_pCurrentFsmState    = &fsm_ExternalInput_off_state_imp;
+	pExternalInput.m_iInputDebounceCount = MIN_INPUT_STABLE_VALUE;
+	pExternalInput.m_pCurrentFsmState    = &fsm_ExternalInput_off_state_imp;
 	// DEBUG_V ("Entring OFF State");
 
 } // fsm_ExternalInput_off_state::Init
 
 /*****************************************************************************/
 // Input was off
-void fsm_ExternalInput_off_state::Poll(c_ExternalInput* pExternalInput)
+void fsm_ExternalInput_off_state::Poll(c_ExternalInput& pExternalInput)
 {
 	// DEBUG_START;
 
 	// read the input
-	bool bInputValue = pExternalInput->ReadInput();
+	bool bInputValue = pExternalInput.ReadInput();
 	
 	// If the input is "on"
 	if (true == bInputValue)
 	{
 		// decrement the counter
-		if (0 == --pExternalInput->m_iInputDebounceCount)
+		if (0 == --pExternalInput.m_iInputDebounceCount)
 		{
 			// we really are on
 			fsm_ExternalInput_on_wait_short_state_imp.Init(pExternalInput);
@@ -254,7 +254,7 @@ void fsm_ExternalInput_off_state::Poll(c_ExternalInput* pExternalInput)
 	{
 		// DEBUG_V ("");
 		// reset the debounce counter
-		pExternalInput->m_iInputDebounceCount = MIN_INPUT_STABLE_VALUE;
+		pExternalInput.m_iInputDebounceCount = MIN_INPUT_STABLE_VALUE;
 	}
 
 	// DEBUG_END;
@@ -265,30 +265,30 @@ void fsm_ExternalInput_off_state::Poll(c_ExternalInput* pExternalInput)
 /*****************************************************************************/
 /*****************************************************************************/
 // Input is on and is stable
-void fsm_ExternalInput_on_wait_short_state::Init(c_ExternalInput* pExternalInput)
+void fsm_ExternalInput_on_wait_short_state::Init(c_ExternalInput& pExternalInput)
 {
 	// DEBUG_START;
 
-	pExternalInput->m_iInputHoldTimeMS = millis() + INPUT_SHORT_VALUE_MS;
-	pExternalInput->m_pCurrentFsmState = &fsm_ExternalInput_on_wait_short_state_imp;
+	pExternalInput.m_iInputHoldTimeMS = millis() + INPUT_SHORT_VALUE_MS;
+	pExternalInput.m_pCurrentFsmState = &fsm_ExternalInput_on_wait_short_state_imp;
 	// DEBUG_V ("Entring Wait Short State");
 
 } // fsm_ExternalInput_on_wait_short_state::Init
 
 /*****************************************************************************/
 // Input is on and is stable
-void fsm_ExternalInput_on_wait_short_state::Poll(c_ExternalInput* pExternalInput)
+void fsm_ExternalInput_on_wait_short_state::Poll(c_ExternalInput& pExternalInput)
 {
 	// DEBUG_START;
 	// read the input
-	bool bInputValue = pExternalInput->ReadInput ();
+	bool bInputValue = pExternalInput.ReadInput ();
 
 	// If the input is "on"
 	if (true == bInputValue)
 	{
 		// DEBUG_V("");
 		// decrement the counter
-		if (millis() >= pExternalInput->m_iInputHoldTimeMS)
+		if (millis() >= pExternalInput.m_iInputHoldTimeMS)
 		{
 			// we really are on
 			fsm_ExternalInput_on_wait_long_state_imp.Init(pExternalInput);
@@ -306,38 +306,38 @@ void fsm_ExternalInput_on_wait_short_state::Poll(c_ExternalInput* pExternalInput
 /*****************************************************************************/
 /*****************************************************************************/
 // Input is always on
-void fsm_ExternalInput_on_wait_long_state::Init (c_ExternalInput* pExternalInput)
+void fsm_ExternalInput_on_wait_long_state::Init (c_ExternalInput& pExternalInput)
 {
-	pExternalInput->m_iInputHoldTimeMS = millis () + INPUT_LONG_VALUE_MS;
-	pExternalInput->m_pCurrentFsmState = &fsm_ExternalInput_on_wait_long_state_imp;
+	pExternalInput.m_iInputHoldTimeMS = millis () + INPUT_LONG_VALUE_MS;
+	pExternalInput.m_pCurrentFsmState = &fsm_ExternalInput_on_wait_long_state_imp;
 	// DEBUG_V ("Entring Wait Long State");
 
 } // fsm_ExternalInput_on_wait_long_state::Init
 
 /*****************************************************************************/
 // Input is on and is stable
-void fsm_ExternalInput_on_wait_long_state::Poll (c_ExternalInput* pExternalInput)
+void fsm_ExternalInput_on_wait_long_state::Poll (c_ExternalInput& pExternalInput)
 {
 	// DEBUG_START;
 
 	// read the input
-	bool bInputValue = pExternalInput->ReadInput ();
+	bool bInputValue = pExternalInput.ReadInput ();
 
 	// If the input is "on"
 	if (true == bInputValue)
 	{
 		// DEBUG_V("");
 		// decrement the counter
-		if (millis () >= pExternalInput->m_iInputHoldTimeMS)
+		if (millis () >= pExternalInput.m_iInputHoldTimeMS)
 		{
 			// we really are on
 			fsm_ExternalInput_wait_for_off_state_imp.Init (pExternalInput);
-			pExternalInput->m_bHadLongPush = true;
+			pExternalInput.m_bHadLongPush = true;
 		}
 	}
 	else // Turned off
 	{
-		pExternalInput->m_bHadShortPush = true;
+		pExternalInput.m_bHadShortPush = true;
 		fsm_ExternalInput_off_state_imp.Init (pExternalInput);
 	}
 
@@ -349,21 +349,21 @@ void fsm_ExternalInput_on_wait_long_state::Poll (c_ExternalInput* pExternalInput
 /*****************************************************************************/
 /*****************************************************************************/
 // Input is always on
-void fsm_ExternalInput_wait_for_off_state::Init (c_ExternalInput* pExternalInput)
+void fsm_ExternalInput_wait_for_off_state::Init (c_ExternalInput& pExternalInput)
 {
-	pExternalInput->m_pCurrentFsmState = &fsm_ExternalInput_wait_for_off_state_imp;
+	pExternalInput.m_pCurrentFsmState = &fsm_ExternalInput_wait_for_off_state_imp;
 	// DEBUG_V ("Entring Wait OFF State");
 
 } // fsm_ExternalInput_wait_for_off_state::Init
 
 /*****************************************************************************/
 // Input is on and is stable
-void fsm_ExternalInput_wait_for_off_state::Poll (c_ExternalInput* pExternalInput)
+void fsm_ExternalInput_wait_for_off_state::Poll (c_ExternalInput& pExternalInput)
 {
 	// DEBUG_START;
 
 	// read the input
-	bool bInputValue = pExternalInput->ReadInput ();
+	bool bInputValue = pExternalInput.ReadInput ();
 
 	// If the input is "on"
 	if (false == bInputValue)

--- a/ESPixelStick/src/input/externalInput.cpp
+++ b/ESPixelStick/src/input/externalInput.cpp
@@ -32,7 +32,7 @@ c_ExternalInput::c_ExternalInput(void) :
 	m_iInputHoldTimeMS(0),
 	m_bHadLongPush(false),
 	m_bHadShortPush(false),
-	m_pCurrentFsmState(&fsm_ExternalInput_boot_imp)
+	m_CurrentFsmState(fsm_ExternalInput_boot_imp)
 {
 	// DEBUG_START;
 	fsm_ExternalInput_boot_imp.Init(*this); // currently redundant, but might Init() might do more ... so important to leave this
@@ -69,7 +69,7 @@ c_ExternalInput::InputValue_t c_ExternalInput::Get()
 {
 	// DEBUG_START;
 
-	return m_pCurrentFsmState->Get();
+	return m_CurrentFsmState.Get();
 
 	// DEBUG_END;
 
@@ -168,7 +168,7 @@ void c_ExternalInput::ProcessConfig (JsonObject JsonData)
 void c_ExternalInput::Poll (void)
 {
 	// DEBUG_START;
-	m_pCurrentFsmState->Poll (*this);
+	m_CurrentFsmState.Poll (*this);
 
 	// DEBUG_END;
 
@@ -209,7 +209,7 @@ bool c_ExternalInput::ReadInput (void)
 // waiting for the system to come up
 void fsm_ExternalInput_boot::Init (c_ExternalInput& pExternalInput)
 {
-	pExternalInput.m_pCurrentFsmState = &fsm_ExternalInput_boot_imp;
+	pExternalInput.m_CurrentFsmState = fsm_ExternalInput_boot_imp;
 
 	// dont do anything
 
@@ -236,7 +236,7 @@ void fsm_ExternalInput_off_state::Init(c_ExternalInput& pExternalInput)
 	// DEBUG_START;
 
 	pExternalInput.m_iInputDebounceCount = MIN_INPUT_STABLE_VALUE;
-	pExternalInput.m_pCurrentFsmState    = &fsm_ExternalInput_off_state_imp;
+	pExternalInput.m_CurrentFsmState    = fsm_ExternalInput_off_state_imp;
 	// DEBUG_V ("Entring OFF State");
 
 } // fsm_ExternalInput_off_state::Init
@@ -280,7 +280,7 @@ void fsm_ExternalInput_on_wait_short_state::Init(c_ExternalInput& pExternalInput
 	// DEBUG_START;
 
 	pExternalInput.m_iInputHoldTimeMS = millis() + INPUT_SHORT_VALUE_MS;
-	pExternalInput.m_pCurrentFsmState = &fsm_ExternalInput_on_wait_short_state_imp;
+	pExternalInput.m_CurrentFsmState = fsm_ExternalInput_on_wait_short_state_imp;
 	// DEBUG_V ("Entring Wait Short State");
 
 } // fsm_ExternalInput_on_wait_short_state::Init
@@ -319,7 +319,7 @@ void fsm_ExternalInput_on_wait_short_state::Poll(c_ExternalInput& pExternalInput
 void fsm_ExternalInput_on_wait_long_state::Init (c_ExternalInput& pExternalInput)
 {
 	pExternalInput.m_iInputHoldTimeMS = millis () + INPUT_LONG_VALUE_MS;
-	pExternalInput.m_pCurrentFsmState = &fsm_ExternalInput_on_wait_long_state_imp;
+	pExternalInput.m_CurrentFsmState = fsm_ExternalInput_on_wait_long_state_imp;
 	// DEBUG_V ("Entring Wait Long State");
 
 } // fsm_ExternalInput_on_wait_long_state::Init
@@ -361,7 +361,7 @@ void fsm_ExternalInput_on_wait_long_state::Poll (c_ExternalInput& pExternalInput
 // Input is always on
 void fsm_ExternalInput_wait_for_off_state::Init (c_ExternalInput& pExternalInput)
 {
-	pExternalInput.m_pCurrentFsmState = &fsm_ExternalInput_wait_for_off_state_imp;
+	pExternalInput.m_CurrentFsmState = fsm_ExternalInput_wait_for_off_state_imp;
 	// DEBUG_V ("Entring Wait OFF State");
 
 } // fsm_ExternalInput_wait_for_off_state::Init

--- a/ESPixelStick/src/input/externalInput.cpp
+++ b/ESPixelStick/src/input/externalInput.cpp
@@ -23,15 +23,6 @@ fsm_ExternalInput_wait_for_off_state  fsm_ExternalInput_wait_for_off_state_imp;
 /*****************************************************************************/
 
 c_ExternalInput::c_ExternalInput(void) :
-	m_name(),
-	m_iPinId(0),
-	m_polarity(Polarity_t::ActiveLow),
-	m_ExpirationTime(0),
-	m_bIsEnabled(false),
-	m_iInputDebounceCount(0),
-	m_iInputHoldTimeMS(0),
-	m_bHadLongPush(false),
-	m_bHadShortPush(false),
 	m_CurrentFsmState(fsm_ExternalInput_boot_imp)
 {
 	// DEBUG_START;

--- a/ESPixelStick/src/input/externalInput.cpp
+++ b/ESPixelStick/src/input/externalInput.cpp
@@ -22,10 +22,20 @@ fsm_ExternalInput_wait_for_off_state  fsm_ExternalInput_wait_for_off_state_imp;
 /* Code                                                                      */
 /*****************************************************************************/
 
-c_ExternalInput::c_ExternalInput(void)
+c_ExternalInput::c_ExternalInput(void) :
+	m_name(),
+	m_iPinId(0),
+	m_polarity(Polarity_t::ActiveLow),
+	m_ExpirationTime(0),
+	m_bIsEnabled(false),
+	m_iInputDebounceCount(0),
+	m_iInputHoldTimeMS(0),
+	m_bHadLongPush(false),
+	m_bHadShortPush(false),
+	m_pCurrentFsmState(&fsm_ExternalInput_boot_imp)
 {
 	// DEBUG_START;
-	fsm_ExternalInput_boot_imp.Init(*this);
+	fsm_ExternalInput_boot_imp.Init(*this); // currently redundant, but might Init() might do more ... so important to leave this
 	// DEBUG_END;
 
 } // c_ExternalInput

--- a/ESPixelStick/src/input/externalInput.h
+++ b/ESPixelStick/src/input/externalInput.h
@@ -55,7 +55,7 @@ protected:
 	uint32_t                  m_iInputHoldTimeMS;
 	bool                      m_bHadLongPush;
 	bool                      m_bHadShortPush;
-	fsm_ExternalInput_state * m_pCurrentFsmState;
+	fsm_ExternalInput_state&  m_CurrentFsmState;
 
 	friend class fsm_ExternalInput_boot;
 	friend class fsm_ExternalInput_off_state;

--- a/ESPixelStick/src/input/externalInput.h
+++ b/ESPixelStick/src/input/externalInput.h
@@ -6,11 +6,11 @@
 
 /*****************************************************************************/
 class fsm_ExternalInput_state;
-class c_ExternalInput
+class c_ExternalInput final
 {
 public:
 	c_ExternalInput (void);
-	virtual ~c_ExternalInput(void) {}
+	~c_ExternalInput(void) {}
 
 	enum InputValue_t
 	{

--- a/ESPixelStick/src/input/externalInput.h
+++ b/ESPixelStick/src/input/externalInput.h
@@ -16,6 +16,8 @@ public:
 	{
 		off = 0,		// input is off
 		on,				// input is on
+		shortOn,		// input was on for 0.5 sec -- NOT CURRENTLY USED/IMPLEMENTED ... must call InputHadShortPush()
+		longOn,         // input was on for 2.0 sec -- NOT CURRENTLY USED/IMPLEMENTED ... must call InputHadLongPush()
 	};
 
 	enum Polarity_t

--- a/ESPixelStick/src/input/externalInput.h
+++ b/ESPixelStick/src/input/externalInput.h
@@ -87,60 +87,64 @@ private:
 /*****************************************************************************/
 // input is unknown and unreachable
 //
-class fsm_ExternalInput_boot : public fsm_ExternalInput_state
+class fsm_ExternalInput_boot final : public fsm_ExternalInput_state
 {
 public:
-	virtual void Poll (c_ExternalInput * pExternalInput);
-	virtual void Init (c_ExternalInput * pExternalInput);
-	virtual c_ExternalInput::InputValue_t Get(void) { return c_ExternalInput::InputValue_t::off; }
-
+	void Poll (c_ExternalInput * pExternalInput) override;
+	void Init (c_ExternalInput * pExternalInput) override;
+	c_ExternalInput::InputValue_t Get(void) override { return c_ExternalInput::InputValue_t::off; }
+	~fsm_ExternalInput_boot() override {};
 }; // fsm_ExternalInput_boot
 
 /*****************************************************************************/
 // input is off and stable
 //
-class fsm_ExternalInput_off_state : public fsm_ExternalInput_state
+class fsm_ExternalInput_off_state final : public fsm_ExternalInput_state
 {
 public:
-	virtual void Poll(c_ExternalInput * pExternalInput);
-	virtual void Init(c_ExternalInput * pExternalInput);
-	virtual c_ExternalInput::InputValue_t Get(void) { return c_ExternalInput::InputValue_t::off; }
+	void Poll(c_ExternalInput * pExternalInput) override;
+	void Init(c_ExternalInput * pExternalInput) override;
+	c_ExternalInput::InputValue_t Get(void) override { return c_ExternalInput::InputValue_t::off; }
+	~fsm_ExternalInput_off_state() override {};
 
 }; // fsm_ExternalInput_off_state
 
 /*****************************************************************************/
 // input is on and is stable
 //
-class fsm_ExternalInput_on_wait_short_state : public fsm_ExternalInput_state
+class fsm_ExternalInput_on_wait_short_state final : public fsm_ExternalInput_state
 {
 public:
-	virtual void Poll(c_ExternalInput * pExternalInput);
-	virtual void Init(c_ExternalInput * pExternalInput);
-	virtual c_ExternalInput::InputValue_t Get(void) { return c_ExternalInput::InputValue_t::on; }
+	void Poll(c_ExternalInput * pExternalInput) override;
+	void Init(c_ExternalInput * pExternalInput) override;
+	c_ExternalInput::InputValue_t Get(void) override { return c_ExternalInput::InputValue_t::on; }
+	~fsm_ExternalInput_on_wait_short_state() override {};
 
 }; // fsm_ExternalInput_on_wait_short_state
 
 /*****************************************************************************/
 // input is always reported as on
 //
-class fsm_ExternalInput_on_wait_long_state : public fsm_ExternalInput_state
+class fsm_ExternalInput_on_wait_long_state final : public fsm_ExternalInput_state
 {
 public:
-	virtual void Poll (c_ExternalInput * pExternalInput);
-	virtual void Init (c_ExternalInput * pExternalInput);
-	virtual c_ExternalInput::InputValue_t Get (void) { return c_ExternalInput::InputValue_t::on; }
+	void Poll (c_ExternalInput * pExternalInput) override;
+	void Init (c_ExternalInput * pExternalInput) override;
+	c_ExternalInput::InputValue_t Get (void) override { return c_ExternalInput::InputValue_t::on; }
+	~fsm_ExternalInput_on_wait_long_state() override {};
 
 }; // fsm_ExternalInput_on_wait_long_state
 
 /*****************************************************************************/
 // input is always reported as on
 //
-class fsm_ExternalInput_wait_for_off_state : public fsm_ExternalInput_state
+class fsm_ExternalInput_wait_for_off_state final : public fsm_ExternalInput_state
 {
 public:
-	virtual void Poll (c_ExternalInput* pExternalInput);
-	virtual void Init (c_ExternalInput* pExternalInput);
-	virtual c_ExternalInput::InputValue_t Get (void) { return c_ExternalInput::InputValue_t::on; }
+	void Poll (c_ExternalInput* pExternalInput) override;
+	void Init (c_ExternalInput* pExternalInput) override;
+	c_ExternalInput::InputValue_t Get (void) override { return c_ExternalInput::InputValue_t::on; }
+	~fsm_ExternalInput_wait_for_off_state() override {};
 
 }; // fsm_ExternalInput_wait_for_off_state
 

--- a/ESPixelStick/src/input/externalInput.h
+++ b/ESPixelStick/src/input/externalInput.h
@@ -47,15 +47,15 @@ protected:
 #   define M_ID         CN_id
 
 	String                    m_name;
-	uint32_t                  m_iPinId              = 0;
-	Polarity_t                m_polarity            = Polarity_t::ActiveLow;
-	time_t                    m_ExpirationTime      = 0;
-	bool                      m_bIsEnabled          = false;
-	uint32_t                  m_iInputDebounceCount = 0;
-	uint32_t                  m_iInputHoldTimeMS    = 0;
-	bool                      m_bHadLongPush        = false;
-	bool                      m_bHadShortPush       = false;
-	fsm_ExternalInput_state * m_pCurrentFsmState    = nullptr;
+	uint32_t                  m_iPinId;
+	Polarity_t                m_polarity;
+	time_t                    m_ExpirationTime;
+	bool                      m_bIsEnabled;
+	uint32_t                  m_iInputDebounceCount;
+	uint32_t                  m_iInputHoldTimeMS;
+	bool                      m_bHadLongPush;
+	bool                      m_bHadShortPush;
+	fsm_ExternalInput_state * m_pCurrentFsmState;
 
 	friend class fsm_ExternalInput_boot;
 	friend class fsm_ExternalInput_off_state;

--- a/ESPixelStick/src/input/externalInput.h
+++ b/ESPixelStick/src/input/externalInput.h
@@ -76,6 +76,7 @@ public:
 	virtual void Poll(c_ExternalInput * pExternalInput) = 0;
 	virtual void Init(c_ExternalInput * pExternalInput) = 0;
 	virtual c_ExternalInput::InputValue_t Get(void)     = 0;
+	virtual ~fsm_ExternalInput_state() {};
 private:
 #define MIN_INPUT_STABLE_VALUE	5
 #define INPUT_SHORT_VALUE_MS    500

--- a/ESPixelStick/src/input/externalInput.h
+++ b/ESPixelStick/src/input/externalInput.h
@@ -15,8 +15,6 @@ public:
 	enum InputValue_t
 	{
 		off = 0,		// input is off
-		shortOn,		// input was on for 0.5 sec
-		longOn,         // input was on for 2.0 sec
 		on,				// input is on
 	};
 

--- a/ESPixelStick/src/input/externalInput.h
+++ b/ESPixelStick/src/input/externalInput.h
@@ -47,15 +47,15 @@ protected:
 #   define M_ID         CN_id
 
 	String                    m_name;
-	uint32_t                  m_iPinId;
-	Polarity_t                m_polarity;
-	time_t                    m_ExpirationTime;
-	bool                      m_bIsEnabled;
-	uint32_t                  m_iInputDebounceCount;
-	uint32_t                  m_iInputHoldTimeMS;
-	bool                      m_bHadLongPush;
-	bool                      m_bHadShortPush;
-	fsm_ExternalInput_state&  m_CurrentFsmState;
+    uint32_t                  m_iPinId              = 0;
+	Polarity_t                m_polarity            = Polarity_t::ActiveLow;
+	time_t                    m_ExpirationTime      = 0;
+	bool                      m_bIsEnabled          = false;
+	uint32_t                  m_iInputDebounceCount = 0;
+	uint32_t                  m_iInputHoldTimeMS    = 0;
+	bool                      m_bHadLongPush        = false;
+	bool                      m_bHadShortPush       = false;
+	fsm_ExternalInput_state&  m_CurrentFsmState;    // initialized in constructor
 
 	friend class fsm_ExternalInput_boot;
 	friend class fsm_ExternalInput_off_state;

--- a/ESPixelStick/src/input/externalInput.h
+++ b/ESPixelStick/src/input/externalInput.h
@@ -73,9 +73,9 @@ protected:
 class fsm_ExternalInput_state
 {
 public:
-	virtual void Poll(c_ExternalInput * pExternalInput) = 0;
-	virtual void Init(c_ExternalInput * pExternalInput) = 0;
-	virtual c_ExternalInput::InputValue_t Get(void)     = 0;
+	virtual void Poll(c_ExternalInput& pExternalInput) = 0;
+	virtual void Init(c_ExternalInput& pExternalInput) = 0;
+	virtual c_ExternalInput::InputValue_t Get(void)    = 0;
 	virtual ~fsm_ExternalInput_state() {};
 private:
 #define MIN_INPUT_STABLE_VALUE	5
@@ -90,8 +90,8 @@ private:
 class fsm_ExternalInput_boot final : public fsm_ExternalInput_state
 {
 public:
-	void Poll (c_ExternalInput * pExternalInput) override;
-	void Init (c_ExternalInput * pExternalInput) override;
+	void Poll (c_ExternalInput& pExternalInput) override;
+	void Init (c_ExternalInput& pExternalInput) override;
 	c_ExternalInput::InputValue_t Get(void) override { return c_ExternalInput::InputValue_t::off; }
 	~fsm_ExternalInput_boot() override {};
 }; // fsm_ExternalInput_boot
@@ -102,8 +102,8 @@ public:
 class fsm_ExternalInput_off_state final : public fsm_ExternalInput_state
 {
 public:
-	void Poll(c_ExternalInput * pExternalInput) override;
-	void Init(c_ExternalInput * pExternalInput) override;
+	void Poll(c_ExternalInput& pExternalInput) override;
+	void Init(c_ExternalInput& pExternalInput) override;
 	c_ExternalInput::InputValue_t Get(void) override { return c_ExternalInput::InputValue_t::off; }
 	~fsm_ExternalInput_off_state() override {};
 
@@ -115,8 +115,8 @@ public:
 class fsm_ExternalInput_on_wait_short_state final : public fsm_ExternalInput_state
 {
 public:
-	void Poll(c_ExternalInput * pExternalInput) override;
-	void Init(c_ExternalInput * pExternalInput) override;
+	void Poll(c_ExternalInput& pExternalInput) override;
+	void Init(c_ExternalInput& pExternalInput) override;
 	c_ExternalInput::InputValue_t Get(void) override { return c_ExternalInput::InputValue_t::on; }
 	~fsm_ExternalInput_on_wait_short_state() override {};
 
@@ -128,8 +128,8 @@ public:
 class fsm_ExternalInput_on_wait_long_state final : public fsm_ExternalInput_state
 {
 public:
-	void Poll (c_ExternalInput * pExternalInput) override;
-	void Init (c_ExternalInput * pExternalInput) override;
+	void Poll (c_ExternalInput& pExternalInput) override;
+	void Init (c_ExternalInput& pExternalInput) override;
 	c_ExternalInput::InputValue_t Get (void) override { return c_ExternalInput::InputValue_t::on; }
 	~fsm_ExternalInput_on_wait_long_state() override {};
 
@@ -141,8 +141,8 @@ public:
 class fsm_ExternalInput_wait_for_off_state final : public fsm_ExternalInput_state
 {
 public:
-	void Poll (c_ExternalInput* pExternalInput) override;
-	void Init (c_ExternalInput* pExternalInput) override;
+	void Poll (c_ExternalInput& pExternalInput) override;
+	void Init (c_ExternalInput& pExternalInput) override;
 	c_ExternalInput::InputValue_t Get (void) override { return c_ExternalInput::InputValue_t::on; }
 	~fsm_ExternalInput_wait_for_off_state() override {};
 

--- a/ESPixelStick/src/network/WiFiDriver.cpp
+++ b/ESPixelStick/src/network/WiFiDriver.cpp
@@ -31,13 +31,15 @@
 #include "../FileMgr.hpp"
 
 //-----------------------------------------------------------------------------
-// Create secrets.h with a #define for SECRETS_SSID and SECRETS_PASS
+// Use platformio_user.ini to define these values.
+// Platformio_user.ini defines these in the [env] section.
 // or delete the #include and enter the strings directly below.
-#include "secrets.h"
-#ifndef SECRETS_SSID
+#if !defined(SECRETS_SSID)
 #   define SECRETS_SSID "DEFAULT_SSID_NOT_SET"
+#endif // SECRETS_SSID
+#if !defined(SECRETS_PASS)
 #   define SECRETS_PASS "DEFAULT_PASSPHRASE_NOT_SET"
-#endif // ndef SECRETS_SSID
+#endif // SECRETS_SSID
 
 /* Fallback configuration if config.json is empty or fails */
 const String default_ssid       = SECRETS_SSID;

--- a/ESPixelStick/src/network/WiFiDriver.cpp
+++ b/ESPixelStick/src/network/WiFiDriver.cpp
@@ -34,7 +34,7 @@
 // Use platformio_user.ini to define these values.
 // Platformio_user.ini defines these in the [env] section.
 // or delete the #include and enter the strings directly below.
-#inlcude "secrets.h"
+#include "secrets.h"
 
 #if !defined(SECRETS_SSID)
 #   define SECRETS_SSID "DEFAULT_SSID_NOT_SET"

--- a/ESPixelStick/src/network/WiFiDriver.cpp
+++ b/ESPixelStick/src/network/WiFiDriver.cpp
@@ -34,6 +34,8 @@
 // Use platformio_user.ini to define these values.
 // Platformio_user.ini defines these in the [env] section.
 // or delete the #include and enter the strings directly below.
+#inlcude "secrets.h"
+
 #if !defined(SECRETS_SSID)
 #   define SECRETS_SSID "DEFAULT_SSID_NOT_SET"
 #endif // SECRETS_SSID

--- a/ESPixelStick/src/network/WiFiDriver.cpp
+++ b/ESPixelStick/src/network/WiFiDriver.cpp
@@ -39,7 +39,7 @@
 #endif // SECRETS_SSID
 #if !defined(SECRETS_PASS)
 #   define SECRETS_PASS "DEFAULT_PASSPHRASE_NOT_SET"
-#endif // SECRETS_SSID
+#endif // SECRETS_PASS
 
 /* Fallback configuration if config.json is empty or fails */
 const String default_ssid       = SECRETS_SSID;

--- a/ESPixelStick/src/service/FPPDiscovery.cpp
+++ b/ESPixelStick/src/service/FPPDiscovery.cpp
@@ -501,14 +501,20 @@ void c_FPPDiscovery::BuildFseqResponse (String fname, c_FileMgr::FileId fseq, St
     JsonData[F ("NumFrames")]       = String (read32 (fsqHeader.TotalNumberOfFramesInSequence, 0));
     JsonData[F ("CompressionType")] = fsqHeader.compressionType;
 
-    char timeStr[72]; // Avoid -Wformat-overflow warning by increasing buffer size from 32 to 72
-    memset (timeStr, 0, sizeof (timeStr));
+    static const int TIME_STR_CHAR_COUNT = 32;
+    char timeStr[TIME_STR_CHAR_COUNT];
     struct tm tm = *gmtime (&MultiSyncStats.lastReceiveTime);
-    sprintf (timeStr, "%4d-%.2d-%.2d %.2d:%.2d:%.2d",
+    // BUGBUG -- trusting the provided `tm` structure values contain valid data ... use `snprintf` to mitigate.
+    int actuallyWritten = snprintf (timeStr, TIME_STR_CHAR_COUNT,
+        "%4d-%.2d-%.2d %.2d:%.2d:%.2d",
         1900 + tm.tm_year, tm.tm_mon + 1, tm.tm_mday,
         tm.tm_hour, tm.tm_min, tm.tm_sec);
 
-    JsonData[F ("lastReceiveTime")] = timeStr;
+    // TODO: assert ((actuallyWritten > 0) && (actuallyWritten < TIME_STR_CHAR_COUNT))
+    if ((actuallyWritten > 0) && (actuallyWritten < TIME_STR_CHAR_COUNT)) {
+        JsonData[F ("lastReceiveTime")] = timeStr;
+    }
+
     JsonData[F ("pktCommand")]      = MultiSyncStats.pktCommand;
     JsonData[F ("pktSyncSeqOpen")]  = MultiSyncStats.pktSyncSeqOpen;
     JsonData[F ("pktSyncSeqStart")] = MultiSyncStats.pktSyncSeqStart;

--- a/ESPixelStick/src/service/FPPDiscovery.cpp
+++ b/ESPixelStick/src/service/FPPDiscovery.cpp
@@ -501,7 +501,7 @@ void c_FPPDiscovery::BuildFseqResponse (String fname, c_FileMgr::FileId fseq, St
     JsonData[F ("NumFrames")]       = String (read32 (fsqHeader.TotalNumberOfFramesInSequence, 0));
     JsonData[F ("CompressionType")] = fsqHeader.compressionType;
 
-    char timeStr[32];
+    char timeStr[72]; // Avoid -Wformat-overflow warning by increasing buffer size from 32 to 72
     memset (timeStr, 0, sizeof (timeStr));
     struct tm tm = *gmtime (&MultiSyncStats.lastReceiveTime);
     sprintf (timeStr, "%4d-%.2d-%.2d %.2d:%.2d:%.2d",

--- a/platformio_user.ini.sample
+++ b/platformio_user.ini.sample
@@ -30,6 +30,9 @@
 ;build_type = debug
 ;monitor_port = COM3
 ;upload_port = COM3
+;build_flags =
+;    -D SECRETS_SSID="DEFAULT_SSID_NOT_SET"
+;    -D SECRETS_PASS="DEFAULT_PASSPHRASE_NOT_SET"
 
 ;[esp8266]
 ;monitor_port = COM4


### PR DESCRIPTION
INCLUDES POTENTIAL SECURITY FIXES.

CHECKS IN A DEFAULT `secrets.h` FILE -- REVIEW REQUESTED.  See [comments](https://github.com/forkineye/ESPixelStick/pull/523#discussion_r862288380).

I've not written any proof-of-concepts for the potential security issues.  I've also not tested the resulting binary yet, so I'm marking as a "Draft" PR for now, to enable early review and comments.

* [x] Fresh clone build break due to missing `secrets.h` file.  Added the file; `.gitignore` already prevents changes from being tracked, and already makes it difficult to push this file.  **REVIEW OF LOCATION REQUESTED** (currently sits next to .INO file).
* [x] `c_ExternalInput` should be marked `final`, and its destructor marked non-virtual.
* [x] Enum `InputValue_t` defines unused states.  Remove `shortOn` and `longOn`.
* [x] `fsm_ExternalInput_state` (FSM abstract class) has not declared a virtual destructor.  [Bad practice](http://www.gotw.ca/publications/mill18.htm)... Easy Fix.
* [x] `fsm_ExternalInput_***` (FSM implementation classes) should be marked `final`.
* [x] `fsm_ExternalInput_***` (FSM implementation classes) should declare functions with `override`.
* [x] FSM abstract class virtual functions take a pointer (not a reference), but presume non-null values.  Easy fix.
* [x] Build Warnings: `-Wformat-overflow=`. Potential stack overflows.  Fairly easy fix.
* [x] `c_ExternalInput` should use reference (not pointer) for FSM member variable, as it is not valid for that to be a null pointer
