### PR TITLE
[WIP] Remove use `sprintf()` (unsafe API)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+/debug/
+/firmware/
+/ESPixelStick/ESPixelStick.ino.cpp
 /.doxygen/doc/
 /.pio/
 /.vscode/

--- a/ESPixelStick/src/ESPixelStick.h
+++ b/ESPixelStick/src/ESPixelStick.h
@@ -31,7 +31,8 @@
 #else
 #	error "Unsupported CPU type"
 #endif
-#include "esp_err.h"
+
+#include "backported.h"
 
 #define ARDUINOJSON_USE_LONG_LONG 1
 
@@ -126,7 +127,7 @@ inline esp_err_t saferRgbToHtmlColorString(char (&output)[N], uint8_t r, uint8_t
     static_assert(N >= 8);
     int wouldHaveWrittenChars = snprintf(output, N, "#%02x%02x%02x", r, g, b);
     // TODO: assert ((wouldHaveWrittenChars > 0) && (wouldHaveWrittenChars < N))
-    if ((wouldHaveWrittenChars > 0) && (wouldHaveWrittenChars < N)) {
+    if ((wouldHaveWrittenChars > 0) && (((size_t)wouldHaveWrittenChars) < N)) {
         return ESP_OK;
     }
     return ESP_FAIL;
@@ -149,7 +150,7 @@ inline esp_err_t saferSecondsToFormattedMinutesAndSecondsString(char (&output)[N
     uint8_t  s = seconds % 60u;
     int wouldHaveWrittenChars = snprintf(output, N, "%u:%02u", m, s);
     // TODO: assert ((wouldHaveWrittenChars > 0) && (wouldHaveWrittenChars < N))
-    if ((wouldHaveWrittenChars > 0) && (wouldHaveWrittenChars < N)) {
+    if ((wouldHaveWrittenChars > 0) && (((size_t)wouldHaveWrittenChars) < N)) {
         return ESP_OK;
     }
     return ESP_FAIL;

--- a/ESPixelStick/src/ESPixelStick.h
+++ b/ESPixelStick/src/ESPixelStick.h
@@ -114,6 +114,7 @@ bool setFromJSON (T& OutValue, J& Json, N Name)
     return HasBeenModified;
 };
 
+// Safer RGB to HTML string (e.g., "#FF8833") conversion function
 // Template function takes array of characters as **reference**
 // to allow template to statically assert buffer is large enough
 // to always succeed.  Returns esp_err_t to allow use of
@@ -133,6 +134,7 @@ inline esp_err_t saferRgbToHtmlColorString(char (&output)[N], uint8_t r, uint8_t
     // TODO: assert ((wouldHaveWrittenChars > 0) && (wouldHaveWrittenChars < N))
     return ESP_FAIL;
 }
+// Safer seconds to "Minutes:Seconds" string conversion function
 // Template function takes array of characters as **reference**
 // to allow template to statically assert buffer is large enough
 // to always succeed.  Returns esp_err_t to allow use of
@@ -157,6 +159,28 @@ inline esp_err_t saferSecondsToFormattedMinutesAndSecondsString(char (&output)[N
     // TODO: assert ((wouldHaveWrittenChars > 0) && (wouldHaveWrittenChars < N))
     return ESP_FAIL;
 }
+// Safer mac to string (e.g., "00:11:22:33:44:55") string conversion function
+// Template function takes array of characters as **reference**
+// to allow template to statically assert buffer is large enough
+// to always succeed.  Returns esp_err_t to allow use of
+// ESP_ERROR_CHECK() macro (as this is used extensively elsewhere).
+template <size_t N, size_t M>
+inline esp_err_t saferMacAddressToString(char (&output)[N], uint8_t (&mac)[M]) {
+    static_assert(N >= 18); // Including the trailing null, the string requires exactly 18 characters.
+    static_assert(M >=  6); // MAC address input must be at least 6 bytes
+    int wouldHaveWrittenChars =
+        snprintf(
+            output, N,
+            "%02X:%02X:%02X:%02X:%02X:%02X",
+            mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+            );
+    if (likely((wouldHaveWrittenChars > 0) && (((size_t)wouldHaveWrittenChars) < N))) {
+        return ESP_OK;
+    }
+    // TODO: assert ((wouldHaveWrittenChars > 0) && (wouldHaveWrittenChars < N))
+    return ESP_FAIL;
+}
+
 
 #define logcon(msg) \
 { \

--- a/ESPixelStick/src/ESPixelStick.h
+++ b/ESPixelStick/src/ESPixelStick.h
@@ -125,6 +125,7 @@ inline esp_err_t saferRgbToHtmlColorString(char (&output)[N], uint8_t r, uint8_t
     // The output is formatted as "#RRGGBB", where RR, GG, and BB are two hex digits
     // for the red, green, and blue components, respectively.
     static_assert(N >= 8);
+    static_assert(sizeof(int) <= sizeof(size_t)); // casting non-negative int to size_t is safe
     int wouldHaveWrittenChars = snprintf(output, N, "#%02x%02x%02x", r, g, b);
     // TODO: assert ((wouldHaveWrittenChars > 0) && (wouldHaveWrittenChars < N))
     if ((wouldHaveWrittenChars > 0) && (((size_t)wouldHaveWrittenChars) < N)) {
@@ -146,6 +147,7 @@ inline esp_err_t saferSecondsToFormattedMinutesAndSecondsString(char (&output)[N
     // therefore, minutes is in range [0..71582788] (eight characters).
     // seconds is always exactly two characters.
     static_assert(N >= 12);
+    static_assert(sizeof(int) <= sizeof(size_t)); // casting non-negative int to size_t is safe
     uint32_t m = seconds / 60u;
     uint8_t  s = seconds % 60u;
     int wouldHaveWrittenChars = snprintf(output, N, "%u:%02u", m, s);

--- a/ESPixelStick/src/ESPixelStick.h
+++ b/ESPixelStick/src/ESPixelStick.h
@@ -112,6 +112,50 @@ bool setFromJSON (T& OutValue, J& Json, N Name)
     return HasBeenModified;
 };
 
+#if defined(esp_err_t)
+// Template function takes array of characters as **reference**
+// to allow template to statically assert buffer is large enough
+// to always succeed.  Returns esp_err_t to allow use of
+// ESP_ERROR_CHECK() macro (as this is used extensively elsewhere).
+template <size_t N>
+inline esp_err_t saferRgbToHtmlColorString(char (&output)[N], uint8_t r, uint8_t g, uint8_t b) {
+    // Including the trailing null, this string requires eight (8) characters.
+    //
+    // The output is formatted as "#RRGGBB", where RR, GG, and BB are two hex digits
+    // for the red, green, and blue components, respectively.
+    static_assert(N >= 8);
+    int wouldHaveWrittenChars = snprintf(output, N, "#%02x%02x%02x", r, g, b);
+    // TODO: assert ((wouldHaveWrittenChars > 0) && (wouldHaveWrittenChars < N))
+    if ((wouldHaveWrittenChars > 0) && (wouldHaveWrittenChars < N)) {
+        return ESP_OK;
+    }
+    return ESP_FAIL;
+}
+// Template function takes array of characters as **reference**
+// to allow template to statically assert buffer is large enough
+// to always succeed.  Returns esp_err_t to allow use of
+// ESP_ERROR_CHECK() macro (as this is used extensively elsewhere).
+template <size_t N>
+inline esp_err_t saferSecondsToFormattedMinutesAndSecondsString(char (&output)[N], uint32_t seconds) {
+
+    // Including the trailing null, the string may require up to twelve (12) characters.
+    //
+    // The output is formatted as "{minutes}:{seconds}".
+    // uint32_t seconds is in range [0..4294967295].
+    // therefore, minutes is in range [0..71582788] (eight characters).
+    // seconds is always exactly two characters.
+    static_assert(N >= 12);
+    uint32_t m = seconds / 60u;
+    uint8_t  s = seconds % 60u;
+    int wouldHaveWrittenChars = snprintf(output, N, "%u:%02u", m, s);
+    // TODO: assert ((wouldHaveWrittenChars > 0) && (wouldHaveWrittenChars < N))
+    if ((wouldHaveWrittenChars > 0) && (wouldHaveWrittenChars < N)) {
+        return ESP_OK;
+    }
+    return ESP_FAIL;
+}
+#endif // defined(esp_err_t)
+
 #define logcon(msg) \
 { \
     String DN; \

--- a/ESPixelStick/src/ESPixelStick.h
+++ b/ESPixelStick/src/ESPixelStick.h
@@ -31,6 +31,7 @@
 #else
 #	error "Unsupported CPU type"
 #endif
+#include "esp_err.h"
 
 #define ARDUINOJSON_USE_LONG_LONG 1
 
@@ -112,7 +113,6 @@ bool setFromJSON (T& OutValue, J& Json, N Name)
     return HasBeenModified;
 };
 
-#if defined(esp_err_t)
 // Template function takes array of characters as **reference**
 // to allow template to statically assert buffer is large enough
 // to always succeed.  Returns esp_err_t to allow use of
@@ -154,7 +154,6 @@ inline esp_err_t saferSecondsToFormattedMinutesAndSecondsString(char (&output)[N
     }
     return ESP_FAIL;
 }
-#endif // defined(esp_err_t)
 
 #define logcon(msg) \
 { \

--- a/ESPixelStick/src/ESPixelStick.h
+++ b/ESPixelStick/src/ESPixelStick.h
@@ -127,10 +127,10 @@ inline esp_err_t saferRgbToHtmlColorString(char (&output)[N], uint8_t r, uint8_t
     static_assert(N >= 8);
     static_assert(sizeof(int) <= sizeof(size_t)); // casting non-negative int to size_t is safe
     int wouldHaveWrittenChars = snprintf(output, N, "#%02x%02x%02x", r, g, b);
-    // TODO: assert ((wouldHaveWrittenChars > 0) && (wouldHaveWrittenChars < N))
-    if ((wouldHaveWrittenChars > 0) && (((size_t)wouldHaveWrittenChars) < N)) {
+    if (likely((wouldHaveWrittenChars > 0) && (((size_t)wouldHaveWrittenChars) < N))) {
         return ESP_OK;
     }
+    // TODO: assert ((wouldHaveWrittenChars > 0) && (wouldHaveWrittenChars < N))
     return ESP_FAIL;
 }
 // Template function takes array of characters as **reference**
@@ -151,10 +151,10 @@ inline esp_err_t saferSecondsToFormattedMinutesAndSecondsString(char (&output)[N
     uint32_t m = seconds / 60u;
     uint8_t  s = seconds % 60u;
     int wouldHaveWrittenChars = snprintf(output, N, "%u:%02u", m, s);
-    // TODO: assert ((wouldHaveWrittenChars > 0) && (wouldHaveWrittenChars < N))
-    if ((wouldHaveWrittenChars > 0) && (((size_t)wouldHaveWrittenChars) < N)) {
+    if (likely((wouldHaveWrittenChars > 0) && (((size_t)wouldHaveWrittenChars) < N))) {
         return ESP_OK;
     }
+    // TODO: assert ((wouldHaveWrittenChars > 0) && (wouldHaveWrittenChars < N))
     return ESP_FAIL;
 }
 

--- a/ESPixelStick/src/backported.h
+++ b/ESPixelStick/src/backported.h
@@ -23,14 +23,14 @@ typedef int esp_err_t; // currently only need two defined status: OK & FAIL
     #define LOG_ERROR_MSG(...)
 #endif
 
-/**
- * Macro which can be used to check the error code,
- * and terminate the program in case the code is not ESP_OK.
- * Prints the error code, error location, and the failed statement to serial output.
- *
- * Disabled if assertions are disabled.
- */
-#ifdef NDEBUG
+#ifndef likely
+    #define likely(x)      __builtin_expect(!!(x), 1)
+#endif
+#ifndef unlikely
+    #define unlikely(x)    __builtin_expect(!!(x), 0)
+#endif
+
+#if defined(NDEBUG)
     #define ESP_ERROR_CHECK(x)                                          \
         do {                                                            \
             esp_err_t err_rc_ = (x);                                    \
@@ -48,7 +48,7 @@ typedef int esp_err_t; // currently only need two defined status: OK & FAIL
     #define ESP_ERROR_CHECK(x)                                          \
         do {                                                            \
             esp_err_t err_rc_ = (x);                                    \
-            if (err_rc_ != ESP_OK) {                                    \
+            if (unlikely(err_rc_ != ESP_OK)) {                          \
                 LOG_ERROR_MSG("err: esp_err_t = %d", rc);               \
                 assert(0 && #x);                                        \
             }                                                           \

--- a/ESPixelStick/src/backported.h
+++ b/ESPixelStick/src/backported.h
@@ -48,13 +48,6 @@ typedef int esp_err_t; // currently only need two defined status: OK & FAIL
     #define ESP_ERROR_CHECK(x)                                          \
         do {                                                            \
             esp_err_t err_rc_ = (x);                                    \
-            if (unlikely(err_rc_ != ESP_OK)) {                          \
-                /* TODO: log error */                                   \
-            }                                                           \
-        } while(0)
-    #define ESP_ERROR_CHECK(x)                                          \
-        do {                                                            \
-            esp_err_t err_rc_ = (x);                                    \
             if (err_rc_ != ESP_OK) {                                    \
                 LOG_ERROR_MSG("err: esp_err_t = %d", rc);               \
                 assert(0 && #x);                                        \

--- a/ESPixelStick/src/backported.h
+++ b/ESPixelStick/src/backported.h
@@ -1,0 +1,78 @@
+#pragma once
+#include <Arduino.h>
+
+
+// ESP32 defines various types and functions that are missing on ESP8266.
+// Backport missing types / macros to allow simpler source management.
+
+#if defined(ARDUINO_ARCH_ESP32)
+#   include "esp_err.h"
+#elif defined(ARDUINO_ARCH_ESP8266)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int esp_err_t; // currently only need two defined status: OK & FAIL
+#define ESP_OK          0
+#define ESP_FAIL        -1
+
+#ifdef DEBUG_ESP_PORT
+    #define LOG_ERROR_MSG(...) DEBUG_ESP_PORT.printf( __VA_ARGS__ )
+#else
+    #define LOG_ERROR_MSG(...)
+#endif
+
+/**
+ * Macro which can be used to check the error code,
+ * and terminate the program in case the code is not ESP_OK.
+ * Prints the error code, error location, and the failed statement to serial output.
+ *
+ * Disabled if assertions are disabled.
+ */
+#ifdef NDEBUG
+    #define ESP_ERROR_CHECK(x)                                          \
+        do {                                                            \
+            esp_err_t err_rc_ = (x);                                    \
+            (void) sizeof(err_rc_);                                     \
+        } while(0)
+#elif defined(CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_SILENT)
+    #define ESP_ERROR_CHECK(x)                                          \
+        do {                                                            \
+            esp_err_t err_rc_ = (x);                                    \
+            if (unlikely(err_rc_ != ESP_OK)) {                          \
+                abort();                                                \
+            }                                                           \
+        } while(0)
+#else
+    #define ESP_ERROR_CHECK(x)                                          \
+        do {                                                            \
+            esp_err_t err_rc_ = (x);                                    \
+            if (unlikely(err_rc_ != ESP_OK)) {                          \
+                /* TODO: log error */                                   \
+            }                                                           \
+        } while(0)
+    #define ESP_ERROR_CHECK(x)                                          \
+        do {                                                            \
+            esp_err_t err_rc_ = (x);                                    \
+            if (err_rc_ != ESP_OK) {                                    \
+                LOG_ERROR_MSG("err: esp_err_t = %d", rc);               \
+                assert(0 && #x);                                        \
+            }                                                           \
+        } while(0);
+
+#endif
+
+
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#else
+#	error "Unsupported CPU type"
+#endif
+
+

--- a/ESPixelStick/src/input/InputAlexa.cpp
+++ b/ESPixelStick/src/input/InputAlexa.cpp
@@ -162,8 +162,9 @@ void c_InputAlexa::onMessage(EspalexaDevice * pDevice)
     {
         OutputMgr.ClearBuffer ();
 
-        char HexColor[] = "#000000 ";
-        sprintf (HexColor, "#%02x%02x%02x", pDevice->getR (), pDevice->getG (), pDevice->getB ());
+        char HexColor[8];
+        ESP_ERROR_CHECK(saferRgbToHtmlColorString(HexColor, pDevice->getR (), pDevice->getG (), pDevice->getB ()));
+
         // DEBUG_V (String ("pDevice->getR: ") + String (pDevice->getR ()));
         // DEBUG_V (String ("pDevice->getG: ") + String (pDevice->getG ()));
         // DEBUG_V (String ("pDevice->getB: ") + String (pDevice->getB ()));

--- a/ESPixelStick/src/input/InputEffectEngine.cpp
+++ b/ESPixelStick/src/input/InputEffectEngine.cpp
@@ -98,8 +98,8 @@ void c_InputEffectEngine::Begin ()
 void c_InputEffectEngine::GetConfig (JsonObject& jsonConfig)
 {
     // DEBUG_START;
-    char HexColor[] = "#000000 ";
-    sprintf (HexColor, "#%02x%02x%02x", EffectColor.r, EffectColor.g, EffectColor.b);
+    char HexColor[8];
+    ESP_ERROR_CHECK(saferRgbToHtmlColorString(HexColor, EffectColor.r, EffectColor.g, EffectColor.b));
     // DEBUG_V ("");
 
     jsonConfig[CN_currenteffect]      = ActiveEffect->name;

--- a/ESPixelStick/src/input/InputFPPRemotePlayEffectFsm.cpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayEffectFsm.cpp
@@ -198,11 +198,8 @@ void fsm_PlayEffect_state_PlayingEffect::GetStatus (JsonObject& jsonStatus)
         SecondsRemaining = 0;
     }
 
-    time_t MinutesRemaining = min (time_t (999), time_t (SecondsRemaining / 60));
-    SecondsRemaining = SecondsRemaining % 60;
-
-    char buf[10];
-    sprintf (buf, "%02u:%02u", uint32_t(MinutesRemaining), uint32_t(SecondsRemaining));
+    char buf[12];
+    ESP_ERROR_CHECK(saferSecondsToFormattedMinutesAndSecondsString(buf, (uint32_t)SecondsRemaining));
     jsonStatus[CN_TimeRemaining] = buf;
 
     p_InputFPPRemotePlayEffect->EffectsEngine.GetStatus (jsonStatus);

--- a/ESPixelStick/src/input/InputFPPRemotePlayFile.cpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayFile.cpp
@@ -177,12 +177,26 @@ void c_InputFPPRemotePlayFile::GetStatus (JsonObject& JsonStatus)
 {
     // xDEBUG_START;
 
-    uint32_t mseconds = FrameControl.ElapsedPlayTimeMS;
-    // BUGBUG -- can overflow, resulting in incorrect time calculation (uint32 * uint32 ==> requires uint64 result)
-    uint32_t msecondsTotal = FrameControl.FrameStepTimeMS * FrameControl.TotalNumberOfFramesInSequence;
+    // NOTE:
+    // variables ending in "Total" reflect total     play time
+    // variables ending in "Rem"   reflect remaining play time
 
-    uint32_t secs = mseconds / 1000;
-    uint32_t secsTot = msecondsTotal / 1000;
+    // File uses milliseconds to store elapsed and total play time
+    uint32_t mseconds = FrameControl.ElapsedPlayTimeMS;
+    uint32_t msecondsTotal;
+    if (__builtin_mul_overflow(FrameControl.FrameStepTimeMS, FrameControl.TotalNumberOfFramesInSequence, &msecondsTotal)) {
+        // returned non-zero: there has been an overflow
+        msecondsTotal = 1000u; // set to one second total when overflow occurs
+    }
+
+    // JsonStatus uses seconds to report elapsed, played, and remaining time
+    uint32_t secs = mseconds / 1000u;
+    uint32_t secsTot = msecondsTotal / 1000u;
+    uint32_t secsRem;
+    if (__builtin_sub_overflow(secsTot, secs, &secsRem)) {
+        // returned non-zero: there has been an overflow
+        secsRem = 0; // set to zero remaining seconds when overflow occurs
+    }
 
     JsonStatus[F ("SyncCount")]           = SyncControl.SyncCount;
     JsonStatus[F ("SyncAdjustmentCount")] = SyncControl.SyncAdjustmentCount;
@@ -193,44 +207,18 @@ void c_InputFPPRemotePlayFile::GetStatus (JsonObject& JsonStatus)
     JsonStatus[CN_playlist]          = temp;
     JsonStatus[CN_seconds_elapsed]   = String (secs);
     JsonStatus[CN_seconds_played]    = String (secs);
-    JsonStatus[CN_seconds_remaining] = String (secsTot - secs);
+    JsonStatus[CN_seconds_remaining] = String (secsRem);
     JsonStatus[CN_sequence_filename] = temp;
     JsonStatus[F("PlayedFileCount")] = PlayedFileCount;
 
-    int mins = secs / 60;
-    secs = secs % 60;
-
-    secsTot = secsTot - secs;
-    int minRem = secsTot / 60;
-    secsTot = secsTot % 60;
-
-
-    // Manual calculation of maximum size string buffer required:
-    // mseconds is uint32         , range [0..4294967295]
-    // mins is 1/(60*1000) of that, range [0..71582]
-    // msecondsTotal is uint32    , range [0..4294967295]
-    // minRem is 1/(60*1000)...   , range [0..4294967295] due to potential for overflow (else 71582)
-    // secs                       , range [0..59]
-    // secsTot                    , range [0..59]
-    //
-    // Therefore, maximum string is for time remaining: "4000111222:33", which requires 14 bytes
-    // If overflow is fixed, the maximum string is:     "71582:99", which requires 9 bytes
-
-    // Avoid use of unsafe `sprintf` ... especially with stack-based buffers
-    static const int TMP_BUFFER_CHAR_COUNT = 14;
-    char buf[TMP_BUFFER_CHAR_COUNT];
-
-    int writtenChars = snprintf (buf, TMP_BUFFER_CHAR_COUNT, "%02d:%02d", mins, secs);
-    // TODO: assert ((writtenChars > 0) && (writtenChars < TMP_BUFFER_CHAR_COUNT))
-    if ((writtenChars > 0) && (writtenChars < TMP_BUFFER_CHAR_COUNT)) {
-        JsonStatus[CN_time_elapsed] = buf;
-    }
-
-    writtenChars = snprintf (buf, TMP_BUFFER_CHAR_COUNT, "%02d:%02d", minRem, secsTot);
-    // TODO: assert ((writtenChars > 0) && (writtenChars < TMP_BUFFER_CHAR_COUNT))
-    if ((writtenChars > 0) && (writtenChars < TMP_BUFFER_CHAR_COUNT)) {
-        JsonStatus[CN_time_remaining] = buf;
-    }
+    // After inserting the total seconds and total seconds remaining,
+    // JsonStatus also includes formatted "minutes + seconds" for both
+    // timeElapsed and timeRemaining
+    char buf[12];
+    ESP_ERROR_CHECK(saferSecondsToFormattedMinutesAndSecondsString(buf, secs));
+    JsonStatus[CN_time_elapsed] = buf;
+    ESP_ERROR_CHECK(saferSecondsToFormattedMinutesAndSecondsString(buf, secsRem));
+    JsonStatus[CN_time_remaining] = buf;
 
     JsonStatus[CN_errors] = LastFailedPlayStatusMsg;
 

--- a/ESPixelStick/src/input/InputFPPRemotePlayList.hpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayList.hpp
@@ -59,6 +59,24 @@ protected:
     c_InputFPPRemotePlayItem * pInputFPPRemotePlayItem = nullptr;
 
     uint32_t PlayListEntryId     = 0;
+
+    // BUGBUG -- time_t creates issues for portable code, and for overflow-safe code
+    // time_t is only required to be a "real" type, which means it can be either a float or an integer.
+    // even when time_t is an integer type, it can be signed or unsigned
+    //
+    // Current code appears to assume that time_t is not a float.
+    //
+    // C++11 does not expose any constant for minimum / maximum value for the time_t type.
+    // This makes it impossible (without type traits) to ensure math operations on time_t types do
+    // not result in undefined behavior (signed types only) and/or overflow (all types).
+    //
+    // Therefore, it is highly recommended to move AWAY from use of time_t wherever possible,
+    // and instead use types that expose their minimum and maximum values, respectively.
+    //
+    // For now, because the code presumes time_t is an integer type, the following assertion
+    // ensures this for all practical purposes.
+    static_assert( (((time_t)1) / 2) == 0 ); // Verify time_t is an integer type (alternative: float)
+
     time_t   PauseEndTime        = 0;
     uint32_t PlayListRepeatCount = 1;
 

--- a/ESPixelStick/src/input/InputFPPRemotePlayListFsm.cpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayListFsm.cpp
@@ -356,22 +356,21 @@ void fsm_PlayList_state_Paused::GetStatus (JsonObject& jsonStatus)
 {
     // DEBUG_START;
 
-    JsonObject PauseStatus = jsonStatus.createNestedObject (CN_Paused);
-    
+    JsonObject pauseStatus = jsonStatus.createNestedObject (CN_Paused);
+
     time_t now = millis ();
 
-    time_t SecondsRemaining = (pInputFPPRemotePlayList->PauseEndTime - now) / 1000;
+    time_t secondsRemaining = (pInputFPPRemotePlayList->PauseEndTime - now) / 1000u;
     if (now > pInputFPPRemotePlayList->PauseEndTime)
     {
-        SecondsRemaining = 0;
+        secondsRemaining = 0;
     }
 
-    time_t MinutesRemaining = min(time_t(99), time_t(SecondsRemaining / 60));
-    SecondsRemaining = SecondsRemaining % 60;
-
-    char buf[10];
-    sprintf (buf, "%02u:%02u", uint32_t(MinutesRemaining), uint32_t(SecondsRemaining));
-    PauseStatus[F ("TimeRemaining")] = buf;
+    char buf[12];
+    // BUGBUG -- casting time_t to integer types is not portable code (can be real ... e.g., float)
+    // BUGBUG -- no portable way to know maximum value of time_t, or if it's signed vs. unsigned (without type traits)
+    ESP_ERROR_CHECK(saferSecondsToFormattedMinutesAndSecondsString(buf, (uint32_t)secondsRemaining));
+    pauseStatus[F ("TimeRemaining")] = buf;
 
     // DEBUG_END;
 

--- a/ESPixelStick/src/network/ETH_m.cpp
+++ b/ESPixelStick/src/network/ETH_m.cpp
@@ -636,7 +636,7 @@ String ETHClass::macAddress(void)
     uint8_t mac[6] = {0,0,0,0,0,0};
     char macStr[18] = { 0 };
     macAddress(mac);
-    sprintf(macStr, "%02X:%02X:%02X:%02X:%02X:%02X", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    ESP_ERROR_CHECK(saferMacAddressToString(macStr, mac));
     return String(macStr);
 }
 


### PR DESCRIPTION
This is a **Work-in-Progress** because it is **NOT YET TESTED / VALIDATED**.

Nonetheless, it is presented to allow comments while final validation occurs.

### Issues

The current code has a number of stack-based arrays that are used to create temporary strings.  Unfortunately, this is currently using `sprintf()`, which is an inherently unsafe API.
These are fixed-format strings, with known input types, so the maximum buffer size that could be required is known to people (not to the compiler).   In fact, the existing buffer sizes **_were_** large enough ... but this was not enforced / verified at compilation.  Therefore, it raised the possibility of adding errors when maintaining the code that would only be found at runtime.

### Goals included

* Enable **_compile-time_** detection that stack-allocated buffers are sufficiently sized for common string conversions
* Do not rely on user-provided array size ... force compiler to detect array size
* Consolidate complex checks into one function (per format string)
* Remove use of inherently-unsafe APIs

### How

The solution combines C++ features to produce a powerful compile-time assurance:
1. C++ allows references to fixed-size arrays as function parameter ... but the array size must be known at compilation.
2. C++ template parameters can be an integral type (e.g., `size_t`)
3. `static_assert()` that the `size_t` template parameter is sufficiently large

Putting these together, the template functions assure (at compile-time) that the parameter is a reference to an array of at least the minimum size.  The caller doesn't pass the array size ... it's inferred by the compiler from the function's argument.  This removes a source of error, while keeping the code clean and easy-to-read.

### Tasks remaining

TODO: Verify each of the following generate identical JSON:
* [ ] `c_InputAlexa::onMessage()`
* [ ] `c_InputEffectEngine::GetConfig()`
* [ ] `fsm_PlayEffect_state_PlayingEffect::GetStatus()`
* [ ] `c_InputFPPRemotePlayFile::GetStatus()`
* [ ] `fsm_PlayList_state_Paused::GetStatus()`
* [ ] `c_EthernetDriver::GetStatus()` (for an ethernet enabled build)

