### PR TITLE
[WIP] Safer string conversion of `tm` struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ secrets.h
 *.ino.generic.bin
 *.gz
 *.pyc
+/MyEnv.txt

--- a/ESPixelStick/ESPixelStick.ino
+++ b/ESPixelStick/ESPixelStick.ino
@@ -497,9 +497,9 @@ void loop()
 void _logcon (String & DriverName, String Message)
 {
     char Spaces[] = { "       " };
-    if (DriverName.length() < (sizeof(Spaces)-1))
+    if (DriverName.length() < (SaferArrayElementCount(Spaces)-1))
     {
-        Spaces[(sizeof (Spaces) - 1) - DriverName.length ()] = '\0';
+        Spaces[(SaferArrayElementCount(Spaces) - 1) - DriverName.length ()] = '\0';
     }
     else
     {

--- a/ESPixelStick/src/ESPixelStick.h
+++ b/ESPixelStick/src/ESPixelStick.h
@@ -19,7 +19,6 @@
 */
 
 #include <Arduino.h>
-
 #if defined(ARDUINO_ARCH_ESP8266)
 #	include <ESP8266WiFi.h>
 #	include <ESPAsyncTCP.h>
@@ -37,9 +36,12 @@
 #include <Ticker.h>
 #include <ArduinoJson.h>
 
+#include "utility/SaferArraySize.hpp"
+
 #include "memdebug.h"
 #include "ConstNames.hpp"
 #include "GPIO_Defs.hpp"
+
 
 #define REBOOT_DELAY    100     ///< Delay for rebooting once reboot flag is set
 #define LOG_PORT        Serial  ///< Serial port for console logging

--- a/ESPixelStick/src/input/InputArtnet.cpp
+++ b/ESPixelStick/src/input/InputArtnet.cpp
@@ -29,7 +29,7 @@ c_InputArtnet::c_InputArtnet (c_InputMgr::e_InputChannelIds NewInputChannelId,
 {
     // DEBUG_START;
     // DEBUG_V ("BufferSize: " + String (BufferSize));
-    memset ((void*)UniverseArray, 0x00, sizeof (UniverseArray));
+    memset ((void*)UniverseArray, 0x00, SaferArrayByteSize(UniverseArray));
     // DEBUG_END;
 } // c_InputArtnet
 

--- a/ESPixelStick/src/input/InputE131.cpp
+++ b/ESPixelStick/src/input/InputE131.cpp
@@ -31,7 +31,7 @@ c_InputE131::c_InputE131 (c_InputMgr::e_InputChannelIds NewInputChannelId,
     // DEBUG_V ("BufferSize: " + String (BufferSize));
     e131 = new ESPAsyncE131 (0);
 
-    memset ((void*)UniverseArray, 0x00, sizeof (UniverseArray));
+    memset ((void*)UniverseArray, 0x00, SaferArrayByteSize(UniverseArray));
 
     // DEBUG_END;
 } // c_InputE131

--- a/ESPixelStick/src/input/InputEffectEngine.cpp
+++ b/ESPixelStick/src/input/InputEffectEngine.cpp
@@ -472,7 +472,8 @@ void c_InputEffectEngine::GetPixel (uint16_t pixelId, CRGB & out)
     if (pixelId < PixelCount)
     {
         byte PixelData[sizeof(CRGB)];
-        OutputMgr.ReadChannelData(size_t(ChannelsPerPixel * pixelId), sizeof(PixelData), PixelData);
+        // TODO: Unwritten presumption that a single channel === a single byte of data
+        OutputMgr.ReadChannelData(size_t(ChannelsPerPixel * pixelId), SaferArrayByteSize(PixelData), PixelData);
 
         out.r = PixelData[0];
         out.g = PixelData[1];

--- a/ESPixelStick/src/input/InputFPPRemotePlayFile.cpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayFile.cpp
@@ -309,7 +309,7 @@ bool c_InputFPPRemotePlayFile::ParseFseqFile ()
         }
 
         // DEBUG_V ("Convert Raw Header into a processed header");
-        memcpy (fsqParsedHeader.header, fsqRawHeader.header, sizeof (fsqParsedHeader.header));
+        memcpy (fsqParsedHeader.header, fsqRawHeader.header, SaferArrayByteSize(fsqParsedHeader.header));
         fsqParsedHeader.dataOffset                    = read16 (fsqRawHeader.dataOffset);
         fsqParsedHeader.minorVersion                  = fsqRawHeader.minorVersion;
         fsqParsedHeader.majorVersion                  = fsqRawHeader.majorVersion;
@@ -362,7 +362,7 @@ bool c_InputFPPRemotePlayFile::ParseFseqFile ()
         FrameControl.DataOffset = fsqParsedHeader.dataOffset;
         FrameControl.ChannelsPerFrame = fsqParsedHeader.channelCount;
 
-        memset ((void*)&SparseRanges, 0x00, sizeof (SparseRanges));
+        memset ((void*)&SparseRanges, 0x00, SaferArrayByteSize(SparseRanges));
         if (fsqParsedHeader.numSparseRanges)
         {
             if (MAX_NUM_SPARSE_RANGES < fsqParsedHeader.numSparseRanges)
@@ -376,7 +376,7 @@ bool c_InputFPPRemotePlayFile::ParseFseqFile ()
 
             FileMgr.ReadSdFile (FileHandleForFileBeingPlayed,
                                 (uint8_t*)&FseqRawRanges[0],
-                                sizeof (FseqRawRanges),
+                                SaferArrayByteSize (FseqRawRanges),
                                 sizeof (FSEQRawHeader) + fsqParsedHeader.numCompressedBlocks * 8);
 
             uint32_t SparseRangeIndex = 0;
@@ -414,7 +414,7 @@ bool c_InputFPPRemotePlayFile::ParseFseqFile ()
             {
                 LastFailedPlayStatusMsg = (String (F ("ParseFseqFile:: Ignoring Range Info. ")) + PlayItemName + F (" No channels defined in Sparse Ranges."));
                 logcon (LastFailedPlayStatusMsg);
-                memset ((void*)&SparseRanges, 0x00, sizeof (SparseRanges));
+                memset ((void*)&SparseRanges, 0x00, SaferArrayByteSize(SparseRanges));
                 SparseRanges[0].ChannelCount = fsqParsedHeader.channelCount;
             }
 
@@ -422,7 +422,7 @@ bool c_InputFPPRemotePlayFile::ParseFseqFile ()
             {
                 LastFailedPlayStatusMsg = (String (F ("ParseFseqFile:: Ignoring Range Info. ")) + PlayItemName + F (" Too many channels defined in Sparse Ranges."));
                 logcon (LastFailedPlayStatusMsg);
-                memset ((void*)&SparseRanges, 0x00, sizeof (SparseRanges));
+                memset ((void*)&SparseRanges, 0x00, SaferArrayByteSize(SparseRanges));
                 SparseRanges[0].ChannelCount = fsqParsedHeader.channelCount;
             }
 
@@ -430,13 +430,13 @@ bool c_InputFPPRemotePlayFile::ParseFseqFile ()
             {
                 LastFailedPlayStatusMsg = (String (F ("ParseFseqFile:: Ignoring Range Info. ")) + PlayItemName + F (" Sparse Range Frame offset + Num channels is larger than frame size."));
                 logcon (LastFailedPlayStatusMsg);
-                memset ((void*)&SparseRanges, 0x00, sizeof (SparseRanges));
+                memset ((void*)&SparseRanges, 0x00, SaferArrayByteSize(SparseRanges));
                 SparseRanges[0].ChannelCount = fsqParsedHeader.channelCount;
             }
         }
         else
         {
-            memset ((void*)&SparseRanges, 0x00, sizeof (SparseRanges));
+            memset ((void*)&SparseRanges, 0x00, SaferArrayByteSize(SparseRanges));
             SparseRanges[0].ChannelCount = fsqParsedHeader.channelCount;
         }
 
@@ -485,7 +485,7 @@ size_t c_InputFPPRemotePlayFile::ReadFile(size_t DestinationIntensityId, size_t 
     {
         size_t NumBytesReadThisPass = FileMgr.ReadSdFile(FileHandleForFileBeingPlayed,
                                                          LocalIntensityBuffer,
-                                                         min((NumBytesToRead - NumBytesRead), sizeof(LocalIntensityBuffer)),
+                                                         min((NumBytesToRead - NumBytesRead), SaferArrayByteSize(LocalIntensityBuffer)),
                                                          FileOffset);
 
         OutputMgr.WriteChannelData(DestinationIntensityId, NumBytesReadThisPass, LocalIntensityBuffer);

--- a/ESPixelStick/src/output/OutputCommon.cpp
+++ b/ESPixelStick/src/output/OutputCommon.cpp
@@ -131,6 +131,8 @@ void c_OutputCommon::ReadChannelData(size_t StartChannelId, size_t ChannelCount,
 
     // DEBUG_V(String("               StartChannelId: 0x") + String(StartChannelId, HEX));
     // DEBUG_V(String("&OutputBuffer[StartChannelId]: 0x") + String(uint(&OutputBuffer[StartChannelId]), HEX));
+
+    // NOTE: ChannelCount is used by callers as both size in bytes && element count.
     memcpy(pTargetData, &pOutputBuffer[StartChannelId], ChannelCount);
 
     // DEBUG_END;

--- a/ESPixelStick/src/output/OutputMgr.cpp
+++ b/ESPixelStick/src/output/OutputMgr.cpp
@@ -185,7 +185,7 @@ c_OutputMgr::c_OutputMgr ()
     ConfigFileName = String (F ("/")) + String (CN_output_config) + F (".json");
 
     // clear the input data buffer
-    memset ((char*)&OutputBuffer[0], 0, sizeof (OutputBuffer));
+    memset ((char*)&OutputBuffer[0], 0, SaferArrayByteSize(OutputBuffer));
 
 } // c_OutputMgr
 
@@ -374,7 +374,8 @@ void c_OutputMgr::CreateNewConfig ()
     // DEBUG_V ();
 
     JsonConfig[CN_cfgver] = CurrentConfigVersion;
-    JsonConfig[F ("MaxChannels")] = sizeof(OutputBuffer);
+    // TODO: Unwritten presumption that a single channel === a single byte of data
+    JsonConfig[F ("MaxChannels")] = SaferArrayByteSize(OutputBuffer);
 
     // DEBUG_V ("for each output type");
     for (auto CurrentOutputType : OutputTypeXlateMap)
@@ -1216,7 +1217,7 @@ void c_OutputMgr::UpdateDisplayBufferReferences (void)
 
     size_t OutputBufferOffset = 0;
 
-    // DEBUG_V (String ("        BufferSize: ") + String (sizeof(OutputBuffer)));
+    // DEBUG_V (String ("        BufferSize: ") + String (SaferArrayByteSize(OutputBuffer)));
     // DEBUG_V (String ("OutputBufferOffset: ") + String (OutputBufferOffset));
 
     for (auto & OutputChannel : OutputChannelDrivers)
@@ -1225,7 +1226,8 @@ void c_OutputMgr::UpdateDisplayBufferReferences (void)
         OutputChannel.pOutputChannelDriver->SetOutputBufferAddress(&OutputBuffer[OutputBufferOffset]);
 
         size_t ChannelsNeeded     = OutputChannel.pOutputChannelDriver->GetNumChannelsNeeded ();
-        size_t AvailableChannels  = sizeof(OutputBuffer) - OutputBufferOffset;
+        // TODO: Unwritten presumption that a single channel === a single byte of data
+        size_t AvailableChannels  = SaferArrayByteSize(OutputBuffer) - OutputBufferOffset;
         size_t ChannelsToAllocate = min (ChannelsNeeded, AvailableChannels);
 
         // DEBUG_V (String ("    ChannelsNeeded: ") + String (ChannelsNeeded));
@@ -1339,6 +1341,7 @@ void c_OutputMgr::ReadChannelData(size_t StartChannelId, size_t ChannelCount, by
 
     do // once
     {
+        // TODO: Unwritten presumption that a single channel === a single byte of data
         if ((StartChannelId + ChannelCount) > UsedBufferSize)
         {
             // DEBUG_V (String("ERROR: Invalid parameters"));
@@ -1392,7 +1395,7 @@ void c_OutputMgr::ClearBuffer()
 {
     // DEBUG_START;
 
-    memset(OutputBuffer, 0x00, sizeof(OutputBuffer));
+    memset(OutputBuffer, 0x00, SaferArrayByteSize(OutputBuffer));
 
     // DEBUG_END;
 

--- a/ESPixelStick/src/output/OutputMgr.hpp
+++ b/ESPixelStick/src/output/OutputMgr.hpp
@@ -52,7 +52,7 @@ public:
     void      GetPortCounts     (uint16_t& PixelCount, uint16_t& SerialCount) {PixelCount = uint16_t(OutputChannelId_End); SerialCount = uint16_t(NUM_UARTS); }
     uint8_t*  GetBufferAddress  () { return OutputBuffer; } ///< Get the address of the buffer into which the E1.31 handler will stuff data
     size_t    GetBufferUsedSize () { return UsedBufferSize; } ///< Get the size (in intensities) of the buffer into which the E1.31 handler will stuff data
-    size_t    GetBufferSize     () { return sizeof(OutputBuffer); } ///< Get the size (in intensities) of the buffer into which the E1.31 handler will stuff data
+    size_t    GetBufferSize     () { return SaferArrayByteSize(OutputBuffer); } ///< Get the size (in intensities) of the buffer into which the E1.31 handler will stuff data
     void      DeleteConfig      () { FileMgr.DeleteConfigFile (ConfigFileName); }
     void      PauseOutputs      (bool NewState);
     void      GetDriverName     (String & Name) { Name = "OutputMgr"; }

--- a/ESPixelStick/src/output/OutputPixel.cpp
+++ b/ESPixelStick/src/output/OutputPixel.cpp
@@ -223,7 +223,7 @@ void c_OutputPixel::updateGammaTable ()
     double tempBrightness = double (brightness) / 100.0;
     // DEBUG_V (String ("tempBrightness: ") + String (tempBrightness));
 
-    for (unsigned int i = 0; i < sizeof (gamma_table); ++i)
+    for (unsigned int i = 0; i < SaferArrayElementCount(gamma_table); ++i)
     {
         // ESP.wdtFeed ();
         gamma_table[i] = (uint8_t)min ((255.0 * pow (i * tempBrightness / 255, gamma) + 0.5), 255.0);

--- a/ESPixelStick/src/output/OutputRelay.cpp
+++ b/ESPixelStick/src/output/OutputRelay.cpp
@@ -69,7 +69,7 @@ c_OutputRelay::c_OutputRelay (c_OutputMgr::e_OutputChannelIds OutputChannelId,
     c_OutputCommon(OutputChannelId, outputGpio, uart, outputType)
 {
     // DEBUG_START;
-    memcpy((char*)OutputList, (char*)RelayChannelDefaultSettings, sizeof(OutputList));
+    memcpy((char*)OutputList, (char*)RelayChannelDefaultSettings, SaferArrayByteSize(OutputList));
 
     // DEBUG_END;
 } // c_OutputRelay

--- a/ESPixelStick/src/output/OutputRmt.cpp
+++ b/ESPixelStick/src/output/OutputRmt.cpp
@@ -29,9 +29,9 @@ c_OutputRmt::c_OutputRmt()
 {
     // DEBUG_START;
 
-    memset((void *)&Intensity2Rmt[0],   0x00, sizeof(Intensity2Rmt));
+    memset((void *)&Intensity2Rmt[0],   0x00, SaferArrayByteSize(Intensity2Rmt));
 #ifdef USE_RMT_DEBUG_COUNTERS
-    memset((void *)&BitTypeCounters[0], 0x00, sizeof(BitTypeCounters));
+    memset((void *)&BitTypeCounters[0], 0x00, SaferArrayByteSize(BitTypeCounters));
 #endif // def USE_RMT_DEBUG_COUNTERS
 
     // DEBUG_END;

--- a/ESPixelStick/src/output/OutputRmt.hpp
+++ b/ESPixelStick/src/output/OutputRmt.hpp
@@ -94,7 +94,10 @@ private:
     volatile rmt_item32_t *RmtEndAddr      = nullptr;
 
 #define NUM_RMT_SLOTS (sizeof(RMTMEM.chan[0].data32) / sizeof(RMTMEM.chan[0].data32[0]))
+// #define NUM_RMT_SLOTS (SaferArrayElementCount(RMTMEM.chan[0].data32)) // BUGBUG - GCC erroneously indicates that this causes side effects
+
 #define MIN_FRAME_TIME_MS 25
+    static_assert(NUM_RMT_SLOTS >= 4); // else, the multiplication by 0.75 will result in zero....
 
     volatile size_t     NumAvailableRmtSlotsToFill  = NUM_RMT_SLOTS;
     const size_t        NumRmtSlotsPerInterrupt     = NUM_RMT_SLOTS * 0.75;

--- a/ESPixelStick/src/output/OutputTM1814.cpp
+++ b/ESPixelStick/src/output/OutputTM1814.cpp
@@ -100,8 +100,8 @@ bool c_OutputTM1814::SetConfig (ArduinoJson::JsonObject& jsonConfig)
     uint8_t PreambleValue = map (CurrentLimit, 1, 100, 0, 63);
     // DEBUG_V (String (" CurrentLimit: ")   + String (CurrentLimit));
     // DEBUG_V (String ("PreambleValue: 0x") + String (PreambleValue, HEX));
-    memset ((void*)(&PreambleData.normal[0]), ~PreambleValue, sizeof (PreambleData.normal));
-    memset ((void*)(&PreambleData.inverted[0]),  PreambleValue, sizeof (PreambleData.inverted));
+    memset ((void*)(&PreambleData.normal[0]), ~PreambleValue,   SaferArrayByteSize(PreambleData.normal));
+    memset ((void*)(&PreambleData.inverted[0]),  PreambleValue, SaferArrayByteSize(PreambleData.inverted));
     SetFramePrependInformation ( (uint8_t*)&PreambleData, sizeof (PreambleData));
 
     SetInvertData (true);

--- a/ESPixelStick/src/output/OutputUart.cpp
+++ b/ESPixelStick/src/output/OutputUart.cpp
@@ -132,7 +132,7 @@ c_OutputUart::c_OutputUart()
 {
     // DEBUG_START;
 
-    memset((void *)&Intensity2Uart[0],   0x00, sizeof(Intensity2Uart));
+    memset((void *)&Intensity2Uart[0],   0x00, SaferArrayByteSize(Intensity2Uart));
     // DEBUG_END;
 } // c_OutputUart
 

--- a/ESPixelStick/src/service/FPPDiscovery.cpp
+++ b/ESPixelStick/src/service/FPPDiscovery.cpp
@@ -437,9 +437,12 @@ void c_FPPDiscovery::sendPingPacket (IPAddress destination)
     memcpy (packet.ipAddress, &ip, 4);
     String Hostname;
     NetworkMgr.GetHostname (Hostname);
-    strcpy (packet.hostName, Hostname.c_str ());
-    strcpy (packet.version, VERSION.c_str());
-    strcpy (packet.hardwareType, FPP_VARIANT_NAME.c_str());
+    // TODO: Untracked dependency: NetworkMgr.GetHostname() result must never exceed 65 characters (FPPPingPacket.hostname)
+    strncpy(packet.hostName,     Hostname.c_str (),        SaferArrayElementCount(packet.hostName));
+    // TODO: Untracked dependency: VERSION                         must never exceed 65 characters (FPPPingPacket.version)
+    strncpy(packet.version,      VERSION.c_str(),          SaferArrayElementCount(packet.version));
+    // TODO: Untracked dependency: FPP_VARIANT_NAME                must never exceed 41 characters (FPPPingPacket.hardwareType)
+    strncpy(packet.hardwareType, FPP_VARIANT_NAME.c_str(), SaferArrayElementCount(packet.hardwareType));
     packet.ranges[0] = 0;
 
     // DEBUG_V ("Send Ping to " + destination.toString());
@@ -570,7 +573,7 @@ void c_FPPDiscovery::BuildFseqResponse (String fname, c_FileMgr::FileId fseq, St
         JsonArray  JsonDataHeaders = JsonData.createNestedArray (F ("variableHeaders"));
 
         char FSEQVariableDataHeaderBuffer[sizeof (FSEQRawVariableDataHeader) + 1];
-        memset ((uint8_t*)FSEQVariableDataHeaderBuffer, 0x00, sizeof (FSEQVariableDataHeaderBuffer));
+        memset ((uint8_t*)FSEQVariableDataHeaderBuffer, 0x00, SaferArrayByteSize(FSEQVariableDataHeaderBuffer));
         FSEQRawVariableDataHeader* pCurrentVariableHeader = (FSEQRawVariableDataHeader*)FSEQVariableDataHeaderBuffer;
 
         while (FileOffsetToCurrentHeaderRecord < FileOffsetToStartOfSequenceData)

--- a/ESPixelStick/src/utility/SaferArraySize.hpp
+++ b/ESPixelStick/src/utility/SaferArraySize.hpp
@@ -1,0 +1,121 @@
+#pragma once
+/*
+* ESPixelStick.h
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2016, 2022 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+*/
+
+#include "../ESPixelStick.h"
+
+// Safer methods to get size of an array.
+// The methods explicitly differentiate between size in bytes vs. element count.
+// Results are constexpr, allowing use of the function(s) in static_assert.
+// Compilation results in a compile-time constant.
+//     (e.g., zero-cost at execution)
+//
+// Below are **over-simplified** examples of why this header exists.
+// In short, it helps drive clarity as to whether the intended result
+// is a size in bytes, or a count of elements, and helps avoids errors
+// from future refactoring.
+//
+// //////////////////////////////////////////////////////////////////////
+// Example #1 - Reduce Cost of Root-Causing Refactoring Errors
+// //////////////////////////////////////////////////////////////////////
+//
+// Consider the valid function:
+//
+// #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+// void foo(void) {
+//     STRUCTURE_TYPE alpha[10];
+//     for (int i = 0; i < ARRAY_SIZE(alpha); i++) {
+//         alpha[i].FieldZeta = i; 
+//     }
+//     // pass the ten structures to various functions
+// }
+//
+// Now, it is later re-factored, so the caller provides the array of structures:
+//
+// void foo(STRUCTURE_TYPE* alpha) {
+//     for (int i = 0; i < ARRAY_SIZE(alpha); i++) {
+//         alpha[i].FieldZeta = i; 
+//     }
+//     // pass the ten structures to various functions
+// }
+//
+// The above code compiles without error.  However, only one element
+// of the array gets initialized.  Havok occurs only at runtime, and
+// typically some time after the above code has finished executing,
+// making this un-fun to root-cause.
+//
+// //////////////////////////////////////////////////////////////////////
+// Example #2 - Element count vs. Byte count confusion:
+// //////////////////////////////////////////////////////////////////////
+//
+// Consider the valid function:
+//
+// struct FIZZ { char data; }; // typ. in some other header file
+// void bar(void) {
+//     FIZZ array[10];
+//     memset(array, 0, 10); // typ. other function expected count of bytes
+//     // pass the ten structures to various functions
+// }
+//
+// Later, the structure is changed.
+//
+// struct FIZZ { char data; char isValid; };
+//
+// As a result, the function bar() function only initialized 5 of
+// the structures to zero ... the rest are uninitialized memory.
+//
+// //////////////////////////////////////////////////////////////////////
+// The above examples are admittedly simple, to where one might think,
+// "But that's obvious... I'd never do that / miss that in code review."
+// In real-world situations, the same underlying issues are often
+// obfuscated by macros, multiple levels of functions, etc.
+//
+// Thus, explicitly stating intent (bytes vs. elements) is preferable.
+// //////////////////////////////////////////////////////////////////////
+
+template <typename T, size_t N>
+constexpr inline  __attribute__((always_inline)) size_t SaferArrayByteSize(T const (&)[N]) noexcept
+{
+    static_assert(N >= 1);
+    static_assert(sizeof(T) >= 1);
+    return N * sizeof(T);
+}
+template <typename T, size_t N>
+constexpr inline  __attribute__((always_inline)) size_t SaferArrayElementCount(T const (&)[N]) noexcept
+{
+    static_assert(N >= 1);
+    static_assert(sizeof(T) >= 1);
+    return N;
+}
+
+// Technically, the compiler is not required to evaluate constexpr at compilation time.
+// This can be forced (where absolutely required, e.g., ISRs), by wrapping the evaluation
+// of the constexpr in the following template:
+//
+// Example:
+//     static_eval<size_t, constexpr_strlen("Hello, World!")>::value
+//
+// At time of initial implementation, no instances were noticed as requiring this.
+//
+template<typename RESULT_TYPE, RESULT_TYPE EXPRESSION>
+struct static_eval
+{
+    static constexpr RESULT_TYPE value = EXPRESSION;
+};
+


### PR DESCRIPTION
Safer string conversion of `tm` struct into readable string.

Changed `sizeof()` (when used on arrays) to be more explicit about the intended result (count of bytes vs. count of elements).  Zero run-time cost.

<details><summary>Codacy Static Analysis simply confirms existing issues</summary><P/>

The three issues that Codacy noted are not **new** issues.  Rather, by converting from `strcpy()` to `strncpy()`, these issues are more easily discovered.  Prior to pushing these changes, I had already added comments about these three unstated, unverified presumptions.  I would ask that this PR be allowed, even though it does not fix these existing issues.

</details>
