### PR TITLE
Workaround for ESP8266 UI not connecting

### DIFF
--- a/ESPixelStick/src/output/OutputMgr.hpp
+++ b/ESPixelStick/src/output/OutputMgr.hpp
@@ -167,7 +167,7 @@ public:
 
 #ifdef ARDUINO_ARCH_ESP8266
 #   define OM_MAX_NUM_CHANNELS      (1200 * 3)
-#   define OM_MAX_CONFIG_SIZE       ((size_t)(5 * 1024))
+#   define OM_MAX_CONFIG_SIZE       ((size_t)(3 * 1024))
 #else // ARDUINO_ARCH_ESP32
 #   ifdef BOARD_HAS_PSRAM
 #       define OM_MAX_NUM_CHANNELS  (7000 * 3)

--- a/ESPixelStick/src/output/OutputServoPCA9685.cpp
+++ b/ESPixelStick/src/output/OutputServoPCA9685.cpp
@@ -34,7 +34,7 @@ c_OutputServoPCA9685::c_OutputServoPCA9685 (c_OutputMgr::e_OutputChannelIds Outp
     uint32_t id = 0;
     for (ServoPCA9685Channel_t &currentServoPCA9685Channel : OutputList)
     {
-        currentServoPCA9685Channel.Id               - id++;
+        currentServoPCA9685Channel.Id               = id++;
         currentServoPCA9685Channel.Enabled          = false;
         currentServoPCA9685Channel.MinLevel         = SERVO_PCA9685_OUTPUT_MIN_PULSE_WIDTH;
         currentServoPCA9685Channel.MaxLevel         = SERVO_PCA9685_OUTPUT_MAX_PULSE_WIDTH;

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP8266_ESP01S.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP8266_ESP01S.hpp
@@ -35,13 +35,13 @@
 // #define SUPPORT_OutputType_APA102           // SPI
 #define SUPPORT_OutputType_DMX              // UART / RMT
 #define SUPPORT_OutputType_GECE             // UART
-#define SUPPORT_OutputType_GS8208           // UART / RMT
+// #define SUPPORT_OutputType_GS8208           // UART / RMT
 #define SUPPORT_OutputType_Renard           // UART / RMT
 #define SUPPORT_OutputType_Serial           // UART / RMT
-#define SUPPORT_OutputType_TM1814           // UART / RMT
-#define SUPPORT_OutputType_UCS1903          // UART / RMT
-#define SUPPORT_OutputType_UCS8903          // UART / RMT
+// #define SUPPORT_OutputType_TM1814           // UART / RMT
+// #define SUPPORT_OutputType_UCS1903          // UART / RMT
+// #define SUPPORT_OutputType_UCS8903          // UART / RMT
 // #define SUPPORT_OutputType_WS2801           // SPI
 #define SUPPORT_OutputType_WS2811           // UART / RMT
-// #define SUPPORT_OutputType_Relay            // GPIO
-// #define SUPPORT_OutputType_Servo_PCA9685    // I2C (default pins)
+#define SUPPORT_OutputType_Relay            // GPIO
+#define SUPPORT_OutputType_Servo_PCA9685    // I2C (default pins)

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP8266_ESPS_V3.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP8266_ESPS_V3.hpp
@@ -35,12 +35,12 @@
 // #define SUPPORT_OutputType_APA102           // SPI
 #define SUPPORT_OutputType_DMX              // UART / RMT
 #define SUPPORT_OutputType_GECE             // UART
-#define SUPPORT_OutputType_GS8208           // UART / RMT
+// #define SUPPORT_OutputType_GS8208           // UART / RMT
 #define SUPPORT_OutputType_Renard           // UART / RMT
 #define SUPPORT_OutputType_Serial           // UART / RMT
-#define SUPPORT_OutputType_TM1814           // UART / RMT
-#define SUPPORT_OutputType_UCS1903          // UART / RMT
-#define SUPPORT_OutputType_UCS8903          // UART / RMT
+// #define SUPPORT_OutputType_TM1814           // UART / RMT
+// #define SUPPORT_OutputType_UCS1903          // UART / RMT
+// #define SUPPORT_OutputType_UCS8903          // UART / RMT
 // #define SUPPORT_OutputType_WS2801           // SPI
 #define SUPPORT_OutputType_WS2811           // UART / RMT
 // #define SUPPORT_OutputType_Relay            // GPIO

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP8266_Generic.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP8266_Generic.hpp
@@ -35,12 +35,12 @@
 // #define SUPPORT_OutputType_APA102           // SPI
 #define SUPPORT_OutputType_DMX              // UART / RMT
 #define SUPPORT_OutputType_GECE             // UART
-#define SUPPORT_OutputType_GS8208           // UART / RMT
+// #define SUPPORT_OutputType_GS8208           // UART / RMT
 #define SUPPORT_OutputType_Renard           // UART / RMT
 #define SUPPORT_OutputType_Serial           // UART / RMT
-#define SUPPORT_OutputType_TM1814           // UART / RMT
-#define SUPPORT_OutputType_UCS1903          // UART / RMT
-#define SUPPORT_OutputType_UCS8903          // UART / RMT
+// #define SUPPORT_OutputType_TM1814           // UART / RMT
+// #define SUPPORT_OutputType_UCS1903          // UART / RMT
+// #define SUPPORT_OutputType_UCS8903          // UART / RMT
 // #define SUPPORT_OutputType_WS2801           // SPI
 #define SUPPORT_OutputType_WS2811           // UART / RMT
 #define SUPPORT_OutputType_Relay            // GPIO

--- a/platformio.ini
+++ b/platformio.ini
@@ -43,7 +43,7 @@ extra_scripts =
 ; https://docs.platformio.org/en/latest/platforms/espressif8266.html ;
 ;~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~;
 [esp8266]
-platform = espressif8266 @ 3.2.0 ; Arduino Core 3.0.2
+platform = espressif8266 @ 3.2.0 ; Arduino Core
 board_build.f_cpu = 160000000L
 board_build.filesystem = littlefs
 board_build.ldscript = eagle.flash.4m2m.ld


### PR DESCRIPTION
This issue is caused by a lack of ram resources preventing the web socket connect procedure from completing. Reducing the Web buffer by 2KB in the ESP8266 build restored functionality but limits the number of Pixel Protocols that can be available in a given 8266 build. A more comprehensive fix will have to be made in the future.