### PR TITLE
Workaround for an issue when using RMT0

### DIFF
--- a/ESPixelStick/src/input/InputFPPRemotePlayFile.cpp
+++ b/ESPixelStick/src/input/InputFPPRemotePlayFile.cpp
@@ -326,19 +326,19 @@ bool c_InputFPPRemotePlayFile::ParseFseqFile ()
 
 // #define DUMP_FSEQ_HEADER
 #ifdef DUMP_FSEQ_HEADER
-        // DEBUG_V (String ("                   dataOffset: ") + String (fsqParsedHeader.dataOffset));
-        // DEBUG_V (String ("                 minorVersion: ") + String (fsqParsedHeader.minorVersion));
-        // DEBUG_V (String ("                 majorVersion: ") + String (fsqParsedHeader.majorVersion));
-        // DEBUG_V (String ("            VariableHdrOffset: ") + String (fsqParsedHeader.VariableHdrOffset));
-        // DEBUG_V (String ("                 channelCount: ") + String (fsqParsedHeader.channelCount));
-        // DEBUG_V (String ("TotalNumberOfFramesInSequence: ") + String (fsqParsedHeader.TotalNumberOfFramesInSequence));
-        // DEBUG_V (String ("                     stepTime: ") + String (fsqParsedHeader.stepTime));
-        // DEBUG_V (String ("                        flags: ") + String (fsqParsedHeader.flags));
-        // DEBUG_V (String ("              compressionType: 0x") + String (fsqParsedHeader.compressionType, HEX));
-        // DEBUG_V (String ("          numCompressedBlocks: ") + String (fsqParsedHeader.numCompressedBlocks));
-        // DEBUG_V (String ("              numSparseRanges: ") + String (fsqParsedHeader.numSparseRanges));
-        // DEBUG_V (String ("                       flags2: ") + String (fsqParsedHeader.flags2));
-        // DEBUG_V (String ("                           id: 0x") + String ((unsigned long)fsqParsedHeader.id, HEX));
+        DEBUG_V (String ("                   dataOffset: ") + String (fsqParsedHeader.dataOffset));
+        DEBUG_V (String ("                 minorVersion: ") + String (fsqParsedHeader.minorVersion));
+        DEBUG_V (String ("                 majorVersion: ") + String (fsqParsedHeader.majorVersion));
+        DEBUG_V (String ("            VariableHdrOffset: ") + String (fsqParsedHeader.VariableHdrOffset));
+        DEBUG_V (String ("                 channelCount: ") + String (fsqParsedHeader.channelCount));
+        DEBUG_V (String ("TotalNumberOfFramesInSequence: ") + String (fsqParsedHeader.TotalNumberOfFramesInSequence));
+        DEBUG_V (String ("                     stepTime: ") + String (fsqParsedHeader.stepTime));
+        DEBUG_V (String ("                        flags: ") + String (fsqParsedHeader.flags));
+        DEBUG_V (String ("              compressionType: 0x") + String (fsqParsedHeader.compressionType, HEX));
+        DEBUG_V (String ("          numCompressedBlocks: ") + String (fsqParsedHeader.numCompressedBlocks));
+        DEBUG_V (String ("              numSparseRanges: ") + String (fsqParsedHeader.numSparseRanges));
+        DEBUG_V (String ("                       flags2: ") + String (fsqParsedHeader.flags2));
+        DEBUG_V (String ("                           id: 0x") + String ((unsigned long)fsqParsedHeader.id, HEX));
 #endif // def DUMP_FSEQ_HEADER
 
         if (fsqParsedHeader.majorVersion != 2 || fsqParsedHeader.compressionType != 0)
@@ -348,10 +348,13 @@ bool c_InputFPPRemotePlayFile::ParseFseqFile ()
             break;
         }
         // DEBUG_V ("");
-
-        if ((fsqParsedHeader.TotalNumberOfFramesInSequence * fsqParsedHeader.channelCount) > FileMgr.GetSdFileSize (FileHandleForFileBeingPlayed))
+        size_t FileSize = FileMgr.GetSdFileSize (FileHandleForFileBeingPlayed);
+        size_t ExpectedSize = fsqParsedHeader.TotalNumberOfFramesInSequence * fsqParsedHeader.channelCount;
+        if ((ExpectedSize) > FileSize)
         {
-            LastFailedPlayStatusMsg = (String (F ("ParseFseqFile:: Could not start. ")) + PlayItemName + F (" File does not contain enough data to meet the Stated Channel Count * Number of Frames value."));
+            LastFailedPlayStatusMsg = (String (F ("ParseFseqFile:: Could not start: ")) + PlayItemName +
+                                      F (" File does not contain enough data to meet the Stated Channel Count * Number of Frames value. Expected ") +
+                                      String (ExpectedSize) + F (", Got: ") + String (FileSize));
             logcon (LastFailedPlayStatusMsg);
             break;
         }

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_CAM.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_CAM.hpp
@@ -22,8 +22,8 @@
 #define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_0
 #define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_1
 
-#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_3
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_3
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_16
 
 #define LED_FLASH_GPIO          gpio_num_t::GPIO_NUM_4
 #define LED_FLASH_OFF           LOW

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_D1_MINI.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_D1_MINI.hpp
@@ -22,9 +22,9 @@
 #define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
 #define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_4
 
-#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_0
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_5
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_0
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_5
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_16
 
 // SPI Output
 #define SUPPORT_SPI_OUTPUT

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_D1_MINI_ETH.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_D1_MINI_ETH.hpp
@@ -24,9 +24,9 @@
 #define DEFAULT_UART_1_GPIO      gpio_num_t::GPIO_NUM_2
 #define DEFAULT_UART_2_GPIO      gpio_num_t::GPIO_NUM_4
 
-#define DEFAULT_RMT_0_GPIO       gpio_num_t::GPIO_NUM_0
-#define DEFAULT_RMT_1_GPIO       gpio_num_t::GPIO_NUM_5
-#define DEFAULT_RMT_2_GPIO       gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_1_GPIO       gpio_num_t::GPIO_NUM_0
+#define DEFAULT_RMT_2_GPIO       gpio_num_t::GPIO_NUM_5
+#define DEFAULT_RMT_3_GPIO       gpio_num_t::GPIO_NUM_16
 
 #define DEFAULT_I2C_SDA          gpio_num_t::GPIO_NUM_21
 #define DEFAULT_I2C_SCL          gpio_num_t::GPIO_NUM_22

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_DevkitC.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_DevkitC.hpp
@@ -22,10 +22,10 @@
 #define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
 #define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_13
 
-#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_12
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_14
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_32
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_33
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_12
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_14
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_32
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_33
 
 // SPI Output
 #define SUPPORT_SPI_OUTPUT

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_ESP3DEUXQuattro_DMX.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_ESP3DEUXQuattro_DMX.hpp
@@ -23,10 +23,10 @@
 #define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_16
 #define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_32
 
-#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_33
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_4
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_12
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_2
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_33
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_4
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_12
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_2
 
 // File Manager - Defnitions must be present even if SD is not supported
 // #define SUPPORT_SD

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_LoLin_D32_PRO.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_LoLin_D32_PRO.hpp
@@ -22,10 +22,10 @@
 #define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
 #define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_13
 
-#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_12
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_14
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_32
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_33
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_12
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_14
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_32
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_33
 
 // SPI Output
 #define SUPPORT_SPI_OUTPUT

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_M5Stack_Atom.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_M5Stack_Atom.hpp
@@ -43,8 +43,8 @@
 #define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_33
 
 // GROVE extension interface
-#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_26 // TxD for RS485 Tail
-//#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_32  // disabled by default due to memory contraints.
+#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_26 // TxD for RS485 Tail
+//#define DEFAULT_RMT_6_GPIO      gpio_num_t::GPIO_NUM_32  // disabled by default due to memory contraints.
 
 // Bottom extension interface
 // Disabled by default, on Atom Matrix I2C is shared with a 6-Axis IMU (MPU-6886)

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_M5Stack_Atom.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_M5Stack_Atom.hpp
@@ -35,12 +35,12 @@
 #define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_19 // TxD for RS485 Base
 
 // Internal neopixel(s)
-#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_27
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_27
 
 // Bottom extension interface
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_22
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_23
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_33
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_22
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_23
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_33
 
 // GROVE extension interface
 #define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_26 // TxD for RS485 Tail

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_MH_ET_LIVE_MiniKit.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_MH_ET_LIVE_MiniKit.hpp
@@ -22,12 +22,12 @@
 #define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
 #define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_13
 
-#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_12
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_14
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_32
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_33
-#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_15
-#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_7
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_12
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_14
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_32
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_33
+#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_15
+#define DEFAULT_RMT_6_GPIO      gpio_num_t::GPIO_NUM_7
 
 // SPI Output
 #define SUPPORT_SPI_OUTPUT

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_Dig-Octa.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_Dig-Octa.hpp
@@ -24,12 +24,12 @@
 #define DEFAULT_UART_1_GPIO      gpio_num_t::GPIO_NUM_0
 #define DEFAULT_UART_2_GPIO      gpio_num_t::GPIO_NUM_1
 
-#define DEFAULT_RMT_0_GPIO       gpio_num_t::GPIO_NUM_2
-#define DEFAULT_RMT_1_GPIO       gpio_num_t::GPIO_NUM_3
-#define DEFAULT_RMT_2_GPIO       gpio_num_t::GPIO_NUM_4
-#define DEFAULT_RMT_3_GPIO       gpio_num_t::GPIO_NUM_5
-#define DEFAULT_RMT_4_GPIO       gpio_num_t::GPIO_NUM_12
-#define DEFAULT_RMT_5_GPIO       gpio_num_t::GPIO_NUM_13
+#define DEFAULT_RMT_1_GPIO       gpio_num_t::GPIO_NUM_2
+#define DEFAULT_RMT_2_GPIO       gpio_num_t::GPIO_NUM_3
+#define DEFAULT_RMT_3_GPIO       gpio_num_t::GPIO_NUM_4
+#define DEFAULT_RMT_4_GPIO       gpio_num_t::GPIO_NUM_5
+#define DEFAULT_RMT_5_GPIO       gpio_num_t::GPIO_NUM_12
+#define DEFAULT_RMT_6_GPIO       gpio_num_t::GPIO_NUM_13
 
 //Power relay output over Q1 or Q1R
 #define DEFAULT_RELAY_GPIO      gpio_num_t::GPIO_NUM_33

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD_AE_Plus.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD_AE_Plus.hpp
@@ -22,13 +22,13 @@
 #define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_16
 #define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_3
 
-#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_1
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_4
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_1
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_4
 
 //AE+ extra 3 outputs (Level-shifted and 33R resistor)
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_21
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_17
-#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_22
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_21
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_17
+#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_22
 
 //Power relay output over Q1 or Q1R
 #define DEFAULT_RELAY_GPIO      gpio_num_t::GPIO_NUM_15

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD_ETH.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD_ETH.hpp
@@ -24,8 +24,8 @@
 #define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_16
 #define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_3
 
-#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_1
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_4
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_1
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_4
 
 //Power relay output over Q1 or Q1R
 #define DEFAULT_RELAY_GPIO      gpio_num_t::GPIO_NUM_15

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_UNO_AE_Plus.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_UNO_AE_Plus.hpp
@@ -23,9 +23,9 @@
 #define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_3
 
 //AE+ extra 3 outputs (Level-shifted and 33R resistor)
-#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_21
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_17
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_22
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_21
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_17
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_22
 
 //Power relay output over Q1 or Q1R
 #define DEFAULT_RELAY_GPIO      gpio_num_t::GPIO_NUM_15

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_TTGO_T8.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_TTGO_T8.hpp
@@ -22,10 +22,10 @@
 #define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_0
 #define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_4
 
-#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_25
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_26
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_27
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_14
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_25
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_26
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_27
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_14
 
 #define LED_SDA                 gpio_num_t::GPIO_NUM_21  // Green LED and SDA. Will light-up if PCA9865 is used.
 

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_TWILIGHTLORD.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_TWILIGHTLORD.hpp
@@ -22,11 +22,11 @@
 #define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
 #define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_4
 
-#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_14
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_31
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_32
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_33
-#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_34
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_14
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_31
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_32
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_33
+#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_34
 
 //I2C
 #define DEFAULT_I2C_SDA         gpio_num_t::GPIO_NUM_5

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_TWILIGHTLORD_ETH.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_TWILIGHTLORD_ETH.hpp
@@ -24,11 +24,11 @@
 #define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
 #define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_4
 
-#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_14
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_31
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_32
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_33
-#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_34
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_14
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_31
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_32
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_33
+#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_34
 
 // Power relay output over Q1 or Q1R
 #define DEFAULT_RELAY_GPIO      gpio_num_t::GPIO_NUM_15

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_WT32ETH01.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_WT32ETH01.hpp
@@ -24,9 +24,9 @@
 #define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
 #define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_4
 
-#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_0
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_5
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_0
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_5
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_16
 
 // #   define SUPPORT_SPI_OUTPUT
 // #define DEFAULT_SPI_DATA_GPIO  gpio_num_t::GPIO_NUM_15


### PR DESCRIPTION
Turned off use of RMT0
Expanded the FSEQ error message when an fseq file is too short.