### PR TITLE
Multiple fixes for channel stalling issues

### DIFF
--- a/ESPixelStick/src/FileMgr.hpp
+++ b/ESPixelStick/src/FileMgr.hpp
@@ -101,6 +101,7 @@ public:
 #endif
 private:
     void   SetSpiIoPins ();
+    void   ResetSdCard ();
 
 #   define SD_CARD_CLK_MHZ     SD_SCK_MHZ(50)  // 50 MHz SPI clock
 

--- a/ESPixelStick/src/output/OutputCommon.cpp
+++ b/ESPixelStick/src/output/OutputCommon.cpp
@@ -70,16 +70,16 @@ void c_OutputCommon::GetStatus (JsonObject & jsonStatus)
     // DEBUG_START;
 
     jsonStatus[CN_id] = OutputChannelId;
-    jsonStatus["framerefreshrate"] = (0 == FrameRefreshTimeInMicroSec) ? 0 : int(MicroSecondsInASecond / FrameRefreshTimeInMicroSec);
+    jsonStatus["framerefreshrate"] = (0 == FrameRefreshTimeInMicroSec) ? 0 : int(MicroSecondsInASecond / FrameDurationInMicroSec);
     jsonStatus["FrameCount"] = FrameCount;
     
-    jsonStatus["ActualFrameDurationMicroSec"] = ActualFrameDurationMicroSec;
-    jsonStatus["FrameMinDurationInMicroSec"]  = FrameMinDurationInMicroSec;
-    jsonStatus["FrameRefreshTimeInMicroSec"]  = FrameRefreshTimeInMicroSec;
-    jsonStatus["FrameStartTimeInMicroSec"]    = FrameStartTimeInMicroSec;
-    jsonStatus["FrameEndTimeInMicroSec"]      = FrameEndTimeInMicroSec;
-    jsonStatus["FrameTimeDeltaUs"]            = FrameTimeDeltaInMicroSec;
-    jsonStatus["micros"]                      = micros();
+    // jsonStatus["ActualFrameDurationMicroSec"] = ActualFrameDurationMicroSec;
+    // jsonStatus["FrameDurationInMicroSec"]     = FrameDurationInMicroSec;
+    // jsonStatus["FrameRefreshTimeInMicroSec"]  = FrameRefreshTimeInMicroSec;
+    // jsonStatus["FrameStartTimeInMicroSec"]    = FrameStartTimeInMicroSec;
+    // jsonStatus["FrameEndTimeInMicroSec"]      = FrameEndTimeInMicroSec;
+    // jsonStatus["FrameTimeDeltaUs"]            = FrameTimeDeltaInMicroSec;
+    // jsonStatus["micros"]                      = micros();
 
     // DEBUG_END;
 } // GetStatus
@@ -93,7 +93,7 @@ void c_OutputCommon::ReportNewFrame ()
 
     FrameRefreshTimeInMicroSec  = Now - FrameStartTimeInMicroSec;
     FrameStartTimeInMicroSec    = Now;
-    FrameEndTimeInMicroSec      = FrameStartTimeInMicroSec + FrameMinDurationInMicroSec;
+    FrameEndTimeInMicroSec      = FrameStartTimeInMicroSec + FrameDurationInMicroSec;
     FrameCount++;
 
     // DEBUG_END;

--- a/ESPixelStick/src/output/OutputCommon.cpp
+++ b/ESPixelStick/src/output/OutputCommon.cpp
@@ -74,10 +74,12 @@ void c_OutputCommon::GetStatus (JsonObject & jsonStatus)
     jsonStatus["FrameCount"] = FrameCount;
     
     jsonStatus["ActualFrameDurationMicroSec"] = ActualFrameDurationMicroSec;
-    jsonStatus["FrameStartTimeInMicroSec"] = FrameStartTimeInMicroSec;
-    jsonStatus["FrameEndTimeInMicroSec"] = FrameEndTimeInMicroSec;
-    jsonStatus["FrameTimeDeltaUs"] = FrameTimeDeltaUs;
-    jsonStatus["micros"] = micros();
+    jsonStatus["FrameMinDurationInMicroSec"]  = FrameMinDurationInMicroSec;
+    jsonStatus["FrameRefreshTimeInMicroSec"]  = FrameRefreshTimeInMicroSec;
+    jsonStatus["FrameStartTimeInMicroSec"]    = FrameStartTimeInMicroSec;
+    jsonStatus["FrameEndTimeInMicroSec"]      = FrameEndTimeInMicroSec;
+    jsonStatus["FrameTimeDeltaUs"]            = FrameTimeDeltaInMicroSec;
+    jsonStatus["micros"]                      = micros();
 
     // DEBUG_END;
 } // GetStatus

--- a/ESPixelStick/src/output/OutputCommon.cpp
+++ b/ESPixelStick/src/output/OutputCommon.cpp
@@ -72,7 +72,12 @@ void c_OutputCommon::GetStatus (JsonObject & jsonStatus)
     jsonStatus[CN_id] = OutputChannelId;
     jsonStatus["framerefreshrate"] = (0 == FrameRefreshTimeInMicroSec) ? 0 : int(MicroSecondsInASecond / FrameRefreshTimeInMicroSec);
     jsonStatus["FrameCount"] = FrameCount;
+    
     jsonStatus["ActualFrameDurationMicroSec"] = ActualFrameDurationMicroSec;
+    jsonStatus["FrameStartTimeInMicroSec"] = FrameStartTimeInMicroSec;
+    jsonStatus["FrameEndTimeInMicroSec"] = FrameEndTimeInMicroSec;
+    jsonStatus["FrameTimeDeltaUs"] = FrameTimeDeltaUs;
+    jsonStatus["micros"] = micros();
 
     // DEBUG_END;
 } // GetStatus

--- a/ESPixelStick/src/output/OutputCommon.hpp
+++ b/ESPixelStick/src/output/OutputCommon.hpp
@@ -81,15 +81,15 @@ protected:
     {
         bool response = false;
         uint32_t Now = micros ();
-        FrameTimeDeltaUs = Now - FrameStartTimeInMicroSec; // how many us since the frame started
+        FrameTimeDeltaInMicroSec = Now - FrameStartTimeInMicroSec; // how many us since the frame started
 
         // did the counter wrap?
         if(Now < FrameStartTimeInMicroSec)
         {
-            FrameTimeDeltaUs = Now + (0 - FrameStartTimeInMicroSec);
+            FrameTimeDeltaInMicroSec = Now + (0 - FrameStartTimeInMicroSec);
         }
 
-        if(FrameTimeDeltaUs > FrameRefreshTimeInMicroSec)
+        if(FrameTimeDeltaInMicroSec > FrameMinDurationInMicroSec)
         {
             response = true;
         }
@@ -100,6 +100,6 @@ private:
     uint32_t    FrameRefreshTimeInMicroSec = 0;
     uint32_t    FrameStartTimeInMicroSec   = 0;
     uint32_t    FrameEndTimeInMicroSec     = 0;
-    uint32_t    FrameTimeDeltaUs           = 0;
+    uint32_t    FrameTimeDeltaInMicroSec           = 0;
 
 }; // c_OutputCommon

--- a/ESPixelStick/src/output/OutputCommon.hpp
+++ b/ESPixelStick/src/output/OutputCommon.hpp
@@ -81,25 +81,18 @@ protected:
     {
         bool response = false;
         uint32_t Now = micros ();
+        FrameTimeDeltaUs = Now - FrameStartTimeInMicroSec; // how many us since the frame started
 
-        // did we wrap around?
-        if(FrameEndTimeInMicroSec < FrameStartTimeInMicroSec)
+        // did the counter wrap?
+        if(Now < FrameStartTimeInMicroSec)
         {
-            // timer wrapped around
-            if((Now < FrameStartTimeInMicroSec) && (Now > FrameEndTimeInMicroSec))
-            {
-                response = true;
-            }
-        }
-        else
-        {
-            // timer did not wrap around
-            if(Now > FrameEndTimeInMicroSec)
-            {
-                response = true;
-            }
+            FrameTimeDeltaUs = Now + (0 - FrameStartTimeInMicroSec);
         }
 
+        if(FrameTimeDeltaUs > FrameRefreshTimeInMicroSec)
+        {
+            response = true;
+        }
         return response;
     }
 
@@ -107,5 +100,6 @@ private:
     uint32_t    FrameRefreshTimeInMicroSec = 0;
     uint32_t    FrameStartTimeInMicroSec   = 0;
     uint32_t    FrameEndTimeInMicroSec     = 0;
+    uint32_t    FrameTimeDeltaUs           = 0;
 
 }; // c_OutputCommon

--- a/ESPixelStick/src/output/OutputCommon.hpp
+++ b/ESPixelStick/src/output/OutputCommon.hpp
@@ -69,7 +69,7 @@ protected:
     OTYPE_t     OutputType                  = OTYPE_t::OutputType_Disabled;
     OID_t       OutputChannelId             = OID_t::OutputChannelId_End;
     bool        HasBeenInitialized          = false;
-    uint32_t    FrameMinDurationInMicroSec  = 25000;
+    uint32_t    FrameDurationInMicroSec  = 25000;
     uint32_t    ActualFrameDurationMicroSec = 50000; // Default time for relays is every 50ms
     uint8_t   * pOutputBuffer               = nullptr;
     uint32_t    OutputBufferSize            = 0;
@@ -89,7 +89,7 @@ protected:
             FrameTimeDeltaInMicroSec = Now + (0 - FrameStartTimeInMicroSec);
         }
 
-        if(FrameTimeDeltaInMicroSec > FrameMinDurationInMicroSec)
+        if(FrameTimeDeltaInMicroSec > FrameDurationInMicroSec)
         {
             response = true;
         }

--- a/ESPixelStick/src/output/OutputGECERmt.cpp
+++ b/ESPixelStick/src/output/OutputGECERmt.cpp
@@ -149,7 +149,7 @@ uint32_t c_OutputGECERmt::Poll ()
 
         // DEBUG_V("get the next frame started");
 
-        if (Rmt.StartNewFrame ())
+        if (Rmt.StartNewFrame (ActualFrameDurationMicroSec))
         {
             ReportNewFrame ();
         }

--- a/ESPixelStick/src/output/OutputGS8208Rmt.cpp
+++ b/ESPixelStick/src/output/OutputGS8208Rmt.cpp
@@ -158,7 +158,7 @@ uint32_t c_OutputGS8208Rmt::Poll ()
 
         // DEBUG_V("get the next frame started");
 
-        if (Rmt.StartNewFrame ())
+        if (Rmt.StartNewFrame (ActualFrameDurationMicroSec))
         {
             ReportNewFrame ();
         }

--- a/ESPixelStick/src/output/OutputMgr.cpp
+++ b/ESPixelStick/src/output/OutputMgr.cpp
@@ -1315,8 +1315,8 @@ void c_OutputMgr::TaskPoll()
             uint32_t DelayInUs = OutputChannel.pOutputChannelDriver->Poll ();
             if(DelayInUs)
             {
-                // convert MicroSecs + 1ms to MilliSecs and then convert to Delay in ticks
-                vTaskDelay(pdMS_TO_TICKS((DelayInUs + 1000) / 1000));
+                // convert MicroSecs to MilliSecs add some buffer and then convert to Delay in ticks
+                vTaskDelay(pdMS_TO_TICKS((DelayInUs / 1000) + 2));
             }
             else
             {

--- a/ESPixelStick/src/output/OutputMgr.cpp
+++ b/ESPixelStick/src/output/OutputMgr.cpp
@@ -1308,20 +1308,22 @@ void c_OutputMgr::TaskPoll()
 
     if (false == IsOutputPaused)
     {
+        bool FoundAnActiveOutputChannel = false;
         // //DEBUG_V();
         for (DriverInfo_t & OutputChannel : OutputChannelDrivers)
         {
             // //DEBUG_V("Start a new channel");
             uint32_t DelayInUs = OutputChannel.pOutputChannelDriver->Poll ();
+
             if(DelayInUs)
             {
-                // convert MicroSecs to MilliSecs add some buffer and then convert to Delay in ticks
-                vTaskDelay(pdMS_TO_TICKS((DelayInUs / 1000) + 2));
+                FoundAnActiveOutputChannel = true;
             }
-            else
-            {
-                vTaskDelay(pdMS_TO_TICKS(1));
-            }
+        }
+
+        if(!FoundAnActiveOutputChannel)
+        {
+            vTaskDelay(pdMS_TO_TICKS(25));
         }
     }
     else

--- a/ESPixelStick/src/output/OutputMgr.cpp
+++ b/ESPixelStick/src/output/OutputMgr.cpp
@@ -491,6 +491,10 @@ void c_OutputMgr::GetStatus (JsonObject & jsonStatus)
 {
     // DEBUG_START;
 
+#if defined(ARDUINO_ARCH_ESP32)
+    // jsonStatus["PollCount"] = PollCount;
+#endif // defined(ARDUINO_ARCH_ESP32)
+
     JsonArray OutputStatus = jsonStatus.createNestedArray (CN_output);
     for (auto & CurrentOutput : OutputChannelDrivers)
     {
@@ -1308,6 +1312,7 @@ void c_OutputMgr::TaskPoll()
 
     if (false == IsOutputPaused)
     {
+        // PollCount ++;
         bool FoundAnActiveOutputChannel = false;
         // //DEBUG_V();
         for (DriverInfo_t & OutputChannel : OutputChannelDrivers)

--- a/ESPixelStick/src/output/OutputMgr.hpp
+++ b/ESPixelStick/src/output/OutputMgr.hpp
@@ -252,6 +252,7 @@ private:
     bool       SerialUartIsActive = true;
 #if defined(ARDUINO_ARCH_ESP32)
     TaskHandle_t myTaskHandle = NULL;
+    // uint32_t PollCount = 0;
 #endif // defined(ARDUINO_ARCH_ESP32)
 
 #define OM_IS_UART (CurrentOutputChannelDriver.PortType == OM_PortType_t::Uart)

--- a/ESPixelStick/src/output/OutputPixel.cpp
+++ b/ESPixelStick/src/output/OutputPixel.cpp
@@ -320,7 +320,7 @@ void c_OutputPixel::SetFrameDurration (float _IntensityBitTimeInUs, uint16_t Blo
     int TotalBlockDelayUs           = int (float (NumBlocks) * BlockDelayUs);
 
     ActualFrameDurationMicroSec = (IntensityBitTimeInUs * TotalBits) + InterFrameGapInMicroSec + TotalBlockDelayUs;
-    FrameMinDurationInMicroSec = max(uint32_t(25000), ActualFrameDurationMicroSec);
+    FrameDurationInMicroSec = max(uint32_t(25000), ActualFrameDurationMicroSec);
     
     // DEBUG_V (String ("           OutputBufferSize: ") + String (OutputBufferSize));
     // DEBUG_V (String ("             PixelGroupSize: ") + String (PixelGroupSize));
@@ -339,7 +339,7 @@ void c_OutputPixel::SetFrameDurration (float _IntensityBitTimeInUs, uint16_t Blo
     // DEBUG_V (String ("       IntensityBitTimeInUs: ") + String (IntensityBitTimeInUs));
     // DEBUG_V (String ("    InterFrameGapInMicroSec: ") + String (InterFrameGapInMicroSec));
     // DEBUG_V (String ("ActualFrameDurationMicroSec: ") + String (ActualFrameDurationMicroSec));
-    // DEBUG_V (String (" FrameMinDurationInMicroSec: ") + String (FrameMinDurationInMicroSec));
+    // DEBUG_V (String (" FrameDurationInMicroSec: ") + String (FrameDurationInMicroSec));
 
     // DEBUG_END;
 

--- a/ESPixelStick/src/output/OutputRmt.cpp
+++ b/ESPixelStick/src/output/OutputRmt.cpp
@@ -233,7 +233,7 @@ void c_OutputRmt::GetStatus (ArduinoJson::JsonObject& jsonStatus)
 
     jsonStatus[F("NumRmtSlotOverruns")] = NumRmtSlotOverruns;
 #ifdef USE_RMT_DEBUG_COUNTERS 
-    JsonObject debugStatus = jsonStatus.createNestedObject("RMT Debug");
+    jsonStatus[F("OutputIsPaused")] = OutputIsPaused;    JsonObject debugStatus = jsonStatus.createNestedObject("RMT Debug");
     debugStatus["RmtChannelId"]                 = OutputRmtConfig.RmtChannelId;
     debugStatus["GPIO"]                         = OutputRmtConfig.DataPin;
     debugStatus["conf0"]                        = String(RMT.conf_ch[OutputRmtConfig.RmtChannelId].conf0.val, HEX);
@@ -582,6 +582,7 @@ bool c_OutputRmt::StartNewFrame ()
     {
         if(OutputIsPaused)
         {
+            // DEBUG_V("Paused");
             break;
         }
 

--- a/ESPixelStick/src/output/OutputRmt.cpp
+++ b/ESPixelStick/src/output/OutputRmt.cpp
@@ -572,7 +572,7 @@ void c_OutputRmt::PauseOutput(bool PauseOutput)
 }
 
 //----------------------------------------------------------------------------
-bool c_OutputRmt::StartNewFrame ()
+bool c_OutputRmt::StartNewFrame (uint32_t FrameDurationInMicroSec)
 {
     // //DEBUG_START;
 
@@ -661,7 +661,7 @@ bool c_OutputRmt::StartNewFrame ()
         RMT.conf_ch[OutputRmtConfig.RmtChannelId].conf1.tx_start = 1;
 
         // wait for the ISR to finish
-        xSemaphoreTake(WaitFrameDone, portMAX_DELAY);
+        xSemaphoreTake(WaitFrameDone, pdMS_TO_TICKS((FrameDurationInMicroSec+2000)/1000));
         Response = true;
     } while(false);
 

--- a/ESPixelStick/src/output/OutputRmt.hpp
+++ b/ESPixelStick/src/output/OutputRmt.hpp
@@ -127,7 +127,7 @@ public:
     virtual ~c_OutputRmt ();
 
     void Begin                                  (OutputRmtConfig_t config);
-    bool StartNewFrame                          ();
+    bool StartNewFrame                          (uint32_t FrameDurationInMicroSec);
     void GetStatus                              (ArduinoJson::JsonObject& jsonStatus);
     void set_pin                                (gpio_num_t _DataPin) { OutputRmtConfig.DataPin = _DataPin; rmt_set_gpio (OutputRmtConfig.RmtChannelId, rmt_mode_t::RMT_MODE_TX, OutputRmtConfig.DataPin, false); }
     void PauseOutput                            (bool State);

--- a/ESPixelStick/src/output/OutputRmt.hpp
+++ b/ESPixelStick/src/output/OutputRmt.hpp
@@ -155,7 +155,7 @@ public:
 
     SemaphoreHandle_t  WaitFrameDone;
 
-#define USE_RMT_DEBUG_COUNTERS
+// #define USE_RMT_DEBUG_COUNTERS
 #ifdef USE_RMT_DEBUG_COUNTERS
    // debug counters
    uint32_t DataCallbackCounter = 0;

--- a/ESPixelStick/src/output/OutputRmt.hpp
+++ b/ESPixelStick/src/output/OutputRmt.hpp
@@ -153,7 +153,9 @@ public:
 
     void IRAM_ATTR ISR_Handler (uint32_t isrFlags);
 
-// #define USE_RMT_DEBUG_COUNTERS
+    SemaphoreHandle_t  WaitFrameDone;
+
+#define USE_RMT_DEBUG_COUNTERS
 #ifdef USE_RMT_DEBUG_COUNTERS
    // debug counters
    uint32_t DataCallbackCounter = 0;

--- a/ESPixelStick/src/output/OutputSerial.cpp
+++ b/ESPixelStick/src/output/OutputSerial.cpp
@@ -249,7 +249,7 @@ void c_OutputSerial::SetFrameDurration ()
     float TotalIntensitiesPerFrame = float(Num_Channels + 1) + SerialHeaderSize + SerialFooterSize;
     float TotalBitsPerFrame        = float(NumBitsPerIntensity) * TotalIntensitiesPerFrame;
     ActualFrameDurationMicroSec    = uint32_t(IntensityBitTimeInUs * TotalBitsPerFrame) + InterFrameGapInMicroSec;
-    FrameMinDurationInMicroSec     = max(uint32_t(25000), ActualFrameDurationMicroSec);
+    FrameDurationInMicroSec     = max(uint32_t(25000), ActualFrameDurationMicroSec);
 
     // DEBUG_V (String ("           CurrentBaudrate: ") + String (CurrentBaudrate));
     // DEBUG_V (String ("      IntensityBitTimeInUs: ") + String (IntensityBitTimeInUs));
@@ -258,7 +258,7 @@ void c_OutputSerial::SetFrameDurration ()
     // DEBUG_V (String ("  TotalIntensitiesPerFrame: ") + String (TotalIntensitiesPerFrame));
     // DEBUG_V (String ("         TotalBitsPerFrame: ") + String (TotalBitsPerFrame));
     // DEBUG_V (String ("ActualFrameDurationMicroSec: ") + String (ActualFrameDurationMicroSec));
-    // DEBUG_V (String ("FrameMinDurationInMicroSec: ") + String (FrameMinDurationInMicroSec));
+    // DEBUG_V (String ("FrameDurationInMicroSec: ") + String (FrameDurationInMicroSec));
 
     // DEBUG_END;
 

--- a/ESPixelStick/src/output/OutputSerialRmt.cpp
+++ b/ESPixelStick/src/output/OutputSerialRmt.cpp
@@ -215,7 +215,7 @@ uint32_t c_OutputSerialRmt::Poll ()
 
         // DEBUG_V("get the next frame started");
 
-        if (Rmt.StartNewFrame ())
+        if (Rmt.StartNewFrame (ActualFrameDurationMicroSec))
         {
             ReportNewFrame ();
         }

--- a/ESPixelStick/src/output/OutputTLS3001Rmt.cpp
+++ b/ESPixelStick/src/output/OutputTLS3001Rmt.cpp
@@ -101,7 +101,7 @@ bool c_OutputTLS3001Rmt::SetConfig (ArduinoJson::JsonObject& jsonConfig)
     bool response = c_OutputTLS3001::SetConfig (jsonConfig);
 
     Rmt.set_pin (DataPin);
-    Rmt.SetMinFrameDurationInUs (FrameMinDurationInMicroSec);
+    Rmt.SetMinFrameDurationInUs (FrameDurationInMicroSec);
 
     // DEBUG_END;
     return response;
@@ -114,7 +114,7 @@ void c_OutputTLS3001Rmt::SetOutputBufferSize (uint32_t NumChannelsAvailable)
     // DEBUG_START;
 
     c_OutputTLS3001::SetOutputBufferSize (NumChannelsAvailable);
-    Rmt.SetMinFrameDurationInUs (FrameMinDurationInMicroSec);
+    Rmt.SetMinFrameDurationInUs (FrameDurationInMicroSec);
 
     // DEBUG_END;
 

--- a/ESPixelStick/src/output/OutputTM1814Rmt.cpp
+++ b/ESPixelStick/src/output/OutputTM1814Rmt.cpp
@@ -163,7 +163,7 @@ uint32_t c_OutputTM1814Rmt::Poll ()
 
         // DEBUG_V("get the next frame started");
 
-        if (Rmt.StartNewFrame ())
+        if (Rmt.StartNewFrame (ActualFrameDurationMicroSec))
         {
             ReportNewFrame ();
         }

--- a/ESPixelStick/src/output/OutputUCS1903Rmt.cpp
+++ b/ESPixelStick/src/output/OutputUCS1903Rmt.cpp
@@ -158,7 +158,7 @@ uint32_t c_OutputUCS1903Rmt::Poll ()
 
         // DEBUG_V("get the next frame started");
 
-        if (Rmt.StartNewFrame ())
+        if (Rmt.StartNewFrame (ActualFrameDurationMicroSec))
         {
             ReportNewFrame ();
         }

--- a/ESPixelStick/src/output/OutputUCS8903Rmt.cpp
+++ b/ESPixelStick/src/output/OutputUCS8903Rmt.cpp
@@ -162,7 +162,7 @@ uint32_t c_OutputUCS8903Rmt::Poll ()
 
         // DEBUG_V("get the next frame started");
 
-        if (Rmt.StartNewFrame ())
+        if (Rmt.StartNewFrame (ActualFrameDurationMicroSec))
         {
             ReportNewFrame ();
         }

--- a/ESPixelStick/src/output/OutputUart.hpp
+++ b/ESPixelStick/src/output/OutputUart.hpp
@@ -135,6 +135,7 @@ private:
     uint32_t        ActiveIsrMask                   = 0;
 #if defined(ARDUINO_ARCH_ESP32)
     intr_handle_t   IsrHandle                       = nullptr;
+    SemaphoreHandle_t  WaitFrameDone;
 #endif // defined(ARDUINO_ARCH_ESP32)
 
     void     IRAM_ATTR      StartNewDataFrame();

--- a/ESPixelStick/src/output/OutputWS2811.cpp
+++ b/ESPixelStick/src/output/OutputWS2811.cpp
@@ -69,6 +69,8 @@ void c_OutputWS2811::GetStatus (ArduinoJson::JsonObject& jsonStatus)
 {
     c_OutputPixel::GetStatus (jsonStatus);
 
+    // jsonStatus["canRefresh"] = canRefresh();
+
 } // GetStatus
 
 //----------------------------------------------------------------------------

--- a/ESPixelStick/src/output/OutputWS2811Rmt.cpp
+++ b/ESPixelStick/src/output/OutputWS2811Rmt.cpp
@@ -164,7 +164,7 @@ uint32_t c_OutputWS2811Rmt::Poll ()
 
         // DEBUG_V("get the next frame started");
 
-        if (Rmt.StartNewFrame ())
+        if (Rmt.StartNewFrame (ActualFrameDurationMicroSec))
         {
             ReportNewFrame ();
         }

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_CAM.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_CAM.hpp
@@ -19,11 +19,11 @@
 */
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_0
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_1
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_0
+#define DEFAULT_RMT_1_GPIO     gpio_num_t::GPIO_NUM_1
 
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_3
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_3
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_16
 
 #define LED_FLASH_GPIO          gpio_num_t::GPIO_NUM_4
 #define LED_FLASH_OFF           LOW

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_D1_MINI.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_D1_MINI.hpp
@@ -19,12 +19,12 @@
 */
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_4
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_2
+#define DEFAULT_RMT_1_GPIO     gpio_num_t::GPIO_NUM_4
 
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_0
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_5
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_0
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_5
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_16
 
 // SPI Output
 #define SUPPORT_SPI_OUTPUT

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_D1_MINI_ETH.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_D1_MINI_ETH.hpp
@@ -21,12 +21,11 @@
 #define SUPPORT_ETHERNET
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO      gpio_num_t::GPIO_NUM_2
-#define DEFAULT_UART_2_GPIO      gpio_num_t::GPIO_NUM_4
-
-#define DEFAULT_RMT_1_GPIO       gpio_num_t::GPIO_NUM_0
-#define DEFAULT_RMT_2_GPIO       gpio_num_t::GPIO_NUM_5
-#define DEFAULT_RMT_3_GPIO       gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_0_GPIO      gpio_num_t::GPIO_NUM_2
+#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_4
+#define DEFAULT_RMT_2_GPIO       gpio_num_t::GPIO_NUM_0
+#define DEFAULT_RMT_3_GPIO       gpio_num_t::GPIO_NUM_5
+#define DEFAULT_RMT_4_GPIO       gpio_num_t::GPIO_NUM_16
 
 #define DEFAULT_I2C_SDA          gpio_num_t::GPIO_NUM_21
 #define DEFAULT_I2C_SCL          gpio_num_t::GPIO_NUM_22

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_DevkitC.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_DevkitC.hpp
@@ -19,13 +19,13 @@
  */
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_13
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_2
+#define DEFAULT_RMT_1_GPIO     gpio_num_t::GPIO_NUM_13
 
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_12
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_14
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_32
-#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_33
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_12
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_14
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_32
+#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_33
 
 // SPI Output
 #define SUPPORT_SPI_OUTPUT

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_ESP3DEUXQuattro_DMX.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_ESP3DEUXQuattro_DMX.hpp
@@ -20,13 +20,13 @@
  */
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_16
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_32
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_1_GPIO     gpio_num_t::GPIO_NUM_32
 
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_33
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_4
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_12
-#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_2
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_33
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_4
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_12
+#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_2
 
 // File Manager - Defnitions must be present even if SD is not supported
 // #define SUPPORT_SD

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_LoLin_D32_PRO.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_LoLin_D32_PRO.hpp
@@ -19,13 +19,13 @@
  */
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_13
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_2
+#define DEFAULT_RMT_1_GPIO     gpio_num_t::GPIO_NUM_13
 
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_12
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_14
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_32
-#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_33
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_12
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_14
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_32
+#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_33
 
 // SPI Output
 #define SUPPORT_SPI_OUTPUT

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_M5Stack_Atom.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_M5Stack_Atom.hpp
@@ -32,7 +32,7 @@
 
 // Output Manager
 // Bottom extension interface
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_19 // TxD for RS485 Base
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_19 // TxD for RS485 Base
 
 // Internal neopixel(s)
 #define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_27

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_MH_ET_LIVE_MiniKit.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_MH_ET_LIVE_MiniKit.hpp
@@ -19,15 +19,15 @@
 */
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_13
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_2
+#define DEFAULT_RMT_1_GPIO     gpio_num_t::GPIO_NUM_13
 
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_12
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_14
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_32
-#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_33
-#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_15
-#define DEFAULT_RMT_6_GPIO      gpio_num_t::GPIO_NUM_7
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_12
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_14
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_32
+#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_33
+#define DEFAULT_RMT_6_GPIO      gpio_num_t::GPIO_NUM_15
+#define DEFAULT_RMT_7_GPIO      gpio_num_t::GPIO_NUM_7
 
 // SPI Output
 #define SUPPORT_SPI_OUTPUT

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_Olimex_Gateway.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_Olimex_Gateway.hpp
@@ -24,12 +24,12 @@
  */
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_4     // Supposed to be SD Card, but R10 not populated
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_12    // Supposed to be SD Card, but R10 not populated
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_4     // Supposed to be SD Card, but R10 not populated
+#define DEFAULT_RMT_1_GPIO     gpio_num_t::GPIO_NUM_12    // Supposed to be SD Card, but R10 not populated
 
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_13    // Tested working
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_16    // Tested working
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_32    // Tested working
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_13    // Tested working
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_16    // Tested working
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_32    // Tested working
 /*
   Notes:
   - GPIOs 4, 12, 13 are for SD Card, but are not actually wired to the SD Card on

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD.hpp
@@ -19,8 +19,8 @@
  */
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_16
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_3
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_1_GPIO     gpio_num_t::GPIO_NUM_3
 
 #define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_1
 #define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_4

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD_AE_Plus.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD_AE_Plus.hpp
@@ -19,16 +19,16 @@
  */
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_16
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_3
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_1_GPIO     gpio_num_t::GPIO_NUM_3
 
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_1
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_4
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_1
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_4
 
 //AE+ extra 3 outputs (Level-shifted and 33R resistor)
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_21
-#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_17
-#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_22
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_21
+#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_17
+#define DEFAULT_RMT_6_GPIO      gpio_num_t::GPIO_NUM_22
 
 //Power relay output over Q1 or Q1R
 #define DEFAULT_RELAY_GPIO      gpio_num_t::GPIO_NUM_15

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD_AE_Plus_8.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD_AE_Plus_8.hpp
@@ -26,9 +26,9 @@
 
 // AE+ extra 3 outputs (Level-shifted and 33R resistor)
 #define DEFAULT_RMT_4_GPIO  gpio_num_t::GPIO_NUM_15 // Output 5
-#define DEFAULT_RMT_5_GPIO  gpio_num_t::GPIO_NUM_12 // Output 6
-#define DEFAULT_RMT_6_GPIO  gpio_num_t::GPIO_NUM_2  // Output 7
-#define DEFAULT_RMT_7_GPIO  gpio_num_t::GPIO_NUM_32 // Output 8
+#define DEFAULT_RMT_5_GPIO  gpio_num_t::GPIO_NUM_21 // Output 6
+#define DEFAULT_RMT_6_GPIO  gpio_num_t::GPIO_NUM_17 // Output 7
+#define DEFAULT_RMT_7_GPIO  gpio_num_t::GPIO_NUM_22 // Output 8
 
 // File Manager
 #define SUPPORT_SD

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD_ETH.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_QUAD_ETH.hpp
@@ -21,11 +21,11 @@
 #define SUPPORT_ETHERNET
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_16
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_3
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_2_GPIO     gpio_num_t::GPIO_NUM_3
 
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_1
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_4
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_1
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_4
 
 //Power relay output over Q1 or Q1R
 #define DEFAULT_RELAY_GPIO      gpio_num_t::GPIO_NUM_15

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_UNO.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_UNO.hpp
@@ -19,8 +19,8 @@
  */
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_16
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_3
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_1_GPIO     gpio_num_t::GPIO_NUM_3
 
 //Power relay output over Q1 or Q1R
 #define DEFAULT_RELAY_GPIO      gpio_num_t::GPIO_NUM_15

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_UNO_AE_Plus.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_UNO_AE_Plus.hpp
@@ -19,13 +19,13 @@
  */
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_16
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_3
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_1_GPIO     gpio_num_t::GPIO_NUM_3
 
 //AE+ extra 3 outputs (Level-shifted and 33R resistor)
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_21
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_17
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_22
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_21
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_17
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_22
 
 //Power relay output over Q1 or Q1R
 #define DEFAULT_RELAY_GPIO      gpio_num_t::GPIO_NUM_15

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_UNO_ESPSV3.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_UNO_ESPSV3.hpp
@@ -19,7 +19,7 @@
  */
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_16
 
 // File Manager - Defnitions must be present even if SD is not supported
 #define SUPPORT_SD

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_UNO_ETH.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_UNO_ETH.hpp
@@ -21,8 +21,8 @@
 #define SUPPORT_ETHERNET
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_16
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_3
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_1_GPIO     gpio_num_t::GPIO_NUM_3
 
 //Power relay output over Q1 or Q1R
 #define DEFAULT_RELAY_GPIO       gpio_num_t::GPIO_NUM_15

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_UNO_ETH_ESPSV3.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_QUINLED_UNO_ETH_ESPSV3.hpp
@@ -21,7 +21,7 @@
 #define SUPPORT_ETHERNET
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_16
 
 //Power relay output over Q1 or Q1R
 // #define DEFAULT_RELAY_GPIO       gpio_num_t::GPIO_NUM_15

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_TTGO_T8.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_TTGO_T8.hpp
@@ -19,13 +19,13 @@
 */
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_0
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_4
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_0
+#define DEFAULT_RMT_1_GPIO     gpio_num_t::GPIO_NUM_4
 
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_25
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_26
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_27
-#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_14
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_25
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_26
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_27
+#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_14
 
 #define LED_SDA                 gpio_num_t::GPIO_NUM_21  // Green LED and SDA. Will light-up if PCA9865 is used.
 

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_TWILIGHTLORD.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_TWILIGHTLORD.hpp
@@ -19,14 +19,14 @@
  */
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_4
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_2
+#define DEFAULT_RMT_1_GPIO     gpio_num_t::GPIO_NUM_4
 
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_14
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_31
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_32
-#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_33
-#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_34
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_14
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_31
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_32
+#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_33
+#define DEFAULT_RMT_6_GPIO      gpio_num_t::GPIO_NUM_34
 
 //I2C
 #define DEFAULT_I2C_SDA         gpio_num_t::GPIO_NUM_5

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_TWILIGHTLORD_ETH.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_TWILIGHTLORD_ETH.hpp
@@ -21,14 +21,14 @@
 #define SUPPORT_ETHERNET
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_4
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_2
+#define DEFAULT_RMT_1_GPIO     gpio_num_t::GPIO_NUM_4
 
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_14
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_31
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_32
-#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_33
-#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_34
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_14
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_31
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_32
+#define DEFAULT_RMT_5_GPIO      gpio_num_t::GPIO_NUM_33
+#define DEFAULT_RMT_6_GPIO      gpio_num_t::GPIO_NUM_34
 
 // Power relay output over Q1 or Q1R
 #define DEFAULT_RELAY_GPIO      gpio_num_t::GPIO_NUM_15

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_WT32ETH01.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_WT32ETH01.hpp
@@ -21,12 +21,12 @@
 #define SUPPORT_ETHERNET
 
 //Output Manager
-#define DEFAULT_UART_1_GPIO     gpio_num_t::GPIO_NUM_2
-#define DEFAULT_UART_2_GPIO     gpio_num_t::GPIO_NUM_4
+#define DEFAULT_RMT_0_GPIO     gpio_num_t::GPIO_NUM_2
+#define DEFAULT_RMT_1_GPIO     gpio_num_t::GPIO_NUM_4
 
-#define DEFAULT_RMT_1_GPIO      gpio_num_t::GPIO_NUM_0
-#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_5
-#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_16
+#define DEFAULT_RMT_2_GPIO      gpio_num_t::GPIO_NUM_0
+#define DEFAULT_RMT_3_GPIO      gpio_num_t::GPIO_NUM_5
+#define DEFAULT_RMT_4_GPIO      gpio_num_t::GPIO_NUM_16
 
 // #   define SUPPORT_SPI_OUTPUT
 // #define DEFAULT_SPI_DATA_GPIO  gpio_num_t::GPIO_NUM_15


### PR DESCRIPTION
Fixed wrap around issue in calculating when a channel can send the next frame.
Added code to make detection of an SD card more reliable when the ESP is rebooted in the middle of a transaction.
ESP32 now exclusively uses RMT output channels. Using UART + RMT was causing issues in the ISR processing.