### PR TITLE
Fixed HTTP Path to config files

### DIFF
--- a/ESPixelStick/src/FileMgr.cpp
+++ b/ESPixelStick/src/FileMgr.cpp
@@ -857,9 +857,18 @@ void c_FileMgr::GetListOfSdFiles (String & Response)
 
         ResponseJsonDoc[F("usedBytes")] = usedBytes;
 
+        if(ResponseJsonDoc.overflowed())
+        {
+            logcon (String(CN_stars) + F ("ERROR: JSON Doc too small to hold the list of SD files") + CN_stars);
+            break;
+        }
+
+        // DEBUG_V(String("ResponseJsonDoc.size(): ") + String(ResponseJsonDoc.size()));
+        Response.reserve(1024);
+        serializeJson (ResponseJsonDoc, Response);
+
     } while (false);
 
-    serializeJson (ResponseJsonDoc, Response);
     // DEBUG_V (String ("Response: ") + Response);
 
     // DEBUG_END;

--- a/ESPixelStick/src/WebMgr.cpp
+++ b/ESPixelStick/src/WebMgr.cpp
@@ -299,7 +299,14 @@ void c_WebMgr::init ()
 
         	[this](AsyncWebServerRequest *request, String filename, uint32_t index, uint8_t *data, uint32_t len, bool final)
         	{
-                // DEBUG_V("Save Chunk - Start");
+                // DEBUG_V("Save File Chunk - Start");
+                // DEBUG_V(String("  url: ") + request->url());
+                // DEBUG_V(String("  len: ") + String(len));
+                // DEBUG_V(String("index: ") + String(index));
+                // DEBUG_V(String("  sum: ") + String(index + len));
+                // DEBUG_V(String(" file: ") + filename);
+                // DEBUG_V(String("final: ") + String(final));
+
             	if(FileMgr.SaveConfigFile(filename, index, data, len, final))
                 {
                     // DEBUG_V("Save Chunk - Success");
@@ -313,7 +320,7 @@ void c_WebMgr::init ()
 
             [this](AsyncWebServerRequest *request, uint8_t *data, uint32_t len, uint32_t index, uint32_t total)
             {
-                // DEBUG_V("Save Chunk - Start");
+                // DEBUG_V("Save Data Chunk - Start");
                 String UploadFileName = request->url().substring(5);
 
                 // DEBUG_V(String("  url: ") + request->url());

--- a/ESPixelStick/src/WebMgr.cpp
+++ b/ESPixelStick/src/WebMgr.cpp
@@ -197,7 +197,7 @@ void c_WebMgr::init ()
     	webServer.on ("/XP", HTTP_GET | HTTP_POST | HTTP_OPTIONS, [](AsyncWebServerRequest* request)
         {
             // DEBUG_V("XP");
-            request->send (200, CN_textSLASHplain, "pong");
+            request->send (200, CN_textSLASHplain, "{\"pong\":true}");
         });
 
     	webServer.on ("/V1", HTTP_GET | HTTP_OPTIONS, [](AsyncWebServerRequest* request)
@@ -254,6 +254,7 @@ void c_WebMgr::init ()
             {
                 String Response;
                 FileMgr.GetListOfSdFiles(Response);
+                // DEBUG_V(String("Files: ") + Response);
                 request->send (200, CN_textSLASHplain, Response);
             }
         });
@@ -381,14 +382,14 @@ void c_WebMgr::init ()
             });
 
         // Static Handlers
-   	 	webServer.serveStatic ("/UpdRecipe",          LittleFS, "/UpdRecipe.json");
-   	 	webServer.serveStatic ("/config.json",        LittleFS, "/config.json");
-   	 	webServer.serveStatic ("/input_config.json",  LittleFS, "/input_config.json");
-   	 	webServer.serveStatic ("/output_config.json", LittleFS, "/output_config.json");
-   	 	webServer.serveStatic ("/admininfo.json",     LittleFS, "/admininfo.json");
+   	 	webServer.serveStatic ("/UpdRecipe",               LittleFS, "/UpdRecipe.json");
+   	 	webServer.serveStatic ("/conf/config.json",        LittleFS, "/config.json");
+   	 	webServer.serveStatic ("/conf/input_config.json",  LittleFS, "/input_config.json");
+   	 	webServer.serveStatic ("/conf/output_config.json", LittleFS, "/output_config.json");
+   	 	webServer.serveStatic ("/conf/admininfo.json",     LittleFS, "/admininfo.json");
 
         // must be last servestatic entry
-    	webServer.serveStatic ("/",                   LittleFS, "/www/").setDefaultFile ("index.html");
+    	webServer.serveStatic ("/",                        LittleFS, "/www/").setDefaultFile ("index.html");
 
         // FS Debugging Handler
         // webServer.serveStatic ("/fs", LittleFS, "/" );

--- a/html/script.js
+++ b/html/script.js
@@ -457,7 +457,7 @@ async function RequestConfigFile(FileName)
 {
     // console.log("RequestConfigFile FileName: " + FileName);
 
-    await $.getJSON("HTTP://" + target + "/" + FileName, function(data)
+    await $.getJSON("HTTP://" + target + "/conf/" + FileName, function(data)
     {
         // console.log("RequestConfigFile: " + JSON.stringify(data));
         ProcessReceivedJsonConfigMessage(data);


### PR DESCRIPTION
Made the path consistent. From an HTTP point of view they all reside in /conf
This also aligns with a pull request pending for xLights.