### PR TITLE
Fixed Ethernet not reliable issue

### DIFF
--- a/ESPixelStick/src/FileMgr.cpp
+++ b/ESPixelStick/src/FileMgr.cpp
@@ -863,11 +863,11 @@ void c_FileMgr::GetListOfSdFiles (String & Response)
             break;
         }
 
-        // DEBUG_V(String("ResponseJsonDoc.size(): ") + String(ResponseJsonDoc.size()));
-        Response.reserve(1024);
-        serializeJson (ResponseJsonDoc, Response);
-
     } while (false);
+
+    // DEBUG_V(String("ResponseJsonDoc.size(): ") + String(ResponseJsonDoc.size()));
+    Response.reserve(1024);
+    serializeJson (ResponseJsonDoc, Response);
 
     // DEBUG_V (String ("Response: ") + Response);
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,7 +38,7 @@ gulp.task('js', function() {
     return gulp.src(['html/js/jquery*.js', 'html/js/bootstrap.js', 'html/js/jqColorPicker.js', 'html/script.js', 'html/js/dropzone.js', 'html/js/FileSaver.js', 'html/script.js'])
         .pipe(plumber())
         .pipe(concat('esps.js'))
-        .pipe(terser({ 'toplevel': true }))
+        .pipe(terser({ 'toplevel': true })) /* comment out this line to debug the script file */
         .pipe(gzip())
         .pipe(gulp.dest('ESPixelStick/data/www'));
 });

--- a/platformio.ini
+++ b/platformio.ini
@@ -103,10 +103,11 @@ extra_scripts = ${env.extra_scripts}
 extends = esp32
 build_flags = ${esp32.build_flags} -mtext-section-literals
 ; platform  = https://github.com/platformio/platform-espressif32.git#48c4226e5240c873dae6b28adbb93ad8ca582b5d
-platform  = https://github.com/platformio/platform-espressif32.git @ ~6.3.2
+; platform  = https://github.com/platformio/platform-espressif32.git#eb7eba4 ; unstable 6.3.2
+platform  = https://github.com/platformio/platform-espressif32.git#8100ac5 ; works 6.3.1
 platform_packages =
-    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.11 ;
-;    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.3 ;
+;    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.11 ;
+    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.3 ;
 ;    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.2 ; runs real slow
 ;    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.1 ; Has general issues
 ;    framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git#2.0.0 ; SD card not stable on cam card


### PR DESCRIPTION
Reverted the Platform version to the last version in which Ethernet worked.
Fixed an SD file reporting issue that sent a bad data record to the UI when no SD card was installed.