### PR TITLE
Made the AP mode use the ssid and passphrase from the STA mode. Allows Secure AP.

### DIFF
--- a/ESPixelStick/src/network/WiFiDriver.cpp
+++ b/ESPixelStick/src/network/WiFiDriver.cpp
@@ -470,20 +470,21 @@ bool c_WiFiDriver::SetConfig (JsonObject & json)
     String sIp = ip.toString ();
     String sGateway = gateway.toString ();
     String sNetmask = netmask.toString ();
-
+    bool apChanged = false;
     ConfigChanged |= setFromJSON (ssid, json, CN_ssid);
-    ConfigChanged |= setFromJSON (passphrase, json, CN_passphrase);
+    apChanged     |= setFromJSON (passphrase, json, CN_passphrase);
     ConfigChanged |= setFromJSON (sIp, json, CN_ip);
     ConfigChanged |= setFromJSON (sNetmask, json, CN_netmask);
     ConfigChanged |= setFromJSON (sGateway, json, CN_gateway);
     ConfigChanged |= setFromJSON (UseDhcp, json, CN_dhcp);
-    bool chanChanged = setFromJSON (ap_channelNumber, json, CN_ap_channel);
-    ConfigChanged |= chanChanged;
+    apChanged     |= setFromJSON (ap_channelNumber, json, CN_ap_channel);
+    ConfigChanged |= apChanged;
     ConfigChanged |= setFromJSON (sta_timeout, json, CN_sta_timeout);
     ConfigChanged |= setFromJSON (ap_fallbackIsEnabled, json, CN_ap_fallback);
     ConfigChanged |= setFromJSON (ap_timeout, json, CN_ap_timeout);
     ConfigChanged |= setFromJSON (RebootOnWiFiFailureToConnect, json, CN_ap_reboot);
     ConfigChanged |= setFromJSON (StayInApMode, json, CN_StayInApMode);
+    ConfigChanged |= apChanged;
 
     // DEBUG_V ("     ip: " + ip);
     // DEBUG_V ("gateway: " + gateway);
@@ -494,14 +495,35 @@ bool c_WiFiDriver::SetConfig (JsonObject & json)
     // pCurrentFsmState->GetStateName(StateName);
     // DEBUG_V(String("       CurrState: ") + StateName);
     
-    if(chanChanged & pCurrentFsmState == &fsm_WiFi_state_ConnectedToSta_imp)
-    {
-        // DEBUG_V("need to cycle the WiFi to move to a new channel");
-        WiFi.softAPdisconnect();
-    }
     ip.fromString (sIp);
     gateway.fromString (sGateway);
     netmask.fromString (sNetmask);
+
+    if((passphrase.length() < 8) && (passphrase.length() > 0))
+    {
+        logcon (String (F ("WiFi Passphrase is too short. Using Empty String")));
+        passphrase = emptyString;
+    }
+
+    if(apChanged)
+    {
+        // DEBUG_V("AP Settings changed");
+        if(pCurrentFsmState == &fsm_WiFi_state_ConnectedToSta_imp)
+        {
+            // DEBUG_V("need to cycle the WiFi to move to new AP settings");
+            WiFi.softAPdisconnect();
+        }
+    }
+    
+    if(ConfigChanged)
+    {
+        // DEBUG_V("WiFi Settings changed");
+        if(pCurrentFsmState == &fsm_WiFi_state_ConnectedToAP_imp)
+        {
+            // DEBUG_V("need to cycle the WiFi to move to new STA settings");
+            WiFi.disconnect();
+        }
+    }
 
     // DEBUG_V (String("ConfigChanged: ") + String(ConfigChanged));
     // DEBUG_END;
@@ -807,7 +829,7 @@ void fsm_WiFi_state_ConnectingAsAP::Init ()
         NetworkMgr.GetHostname (Hostname);
         String ssid = "ESPixelStick-" + String (Hostname);
         // DEBUG_V(String("ap_channelNumber: ") + String(pWiFiDriver->ap_channelNumber));
-        WiFi.softAP (ssid.c_str (), NULL, pWiFiDriver->ap_channelNumber);
+        WiFi.softAP (ssid.c_str (), pWiFiDriver->passphrase.c_str (), int(pWiFiDriver->ap_channelNumber));
 
         pWiFiDriver->setIpAddress (WiFi.localIP ());
         pWiFiDriver->setIpSubNetMask (WiFi.subnetMask ());


### PR DESCRIPTION
- If passphrase is empty (default) then the AP runs in open mode. 
- If passphrase is not empty, then in AP mode the device will run in secured mode.
- If ssid is empty (default), then an AP ssid is generated as it was in the previous versions.
- If ssid has been configured, then the AP will use the configured ssid value.
