### PR TITLE
Fixed broken SD functionality

### DIFF
--- a/ESPixelStick/src/WebMgr.cpp
+++ b/ESPixelStick/src/WebMgr.cpp
@@ -648,14 +648,15 @@ size_t c_WebMgr::GetFseqFileListChunk(uint8_t *buffer, size_t maxlen, size_t ind
             }
             break;
         }
-        // is it a new request
+
+        // DEBUG_V("is it a new request");
         if (index == 0)
         {
             NumberOfBytesTransfered = 0;             // reset the log line index when we get a new request
             TotalFileSizeToTransfer = 0;
             buffer[0] = '\0';
 
-            // Try to open the file
+            // DEBUG_V("Try to open the file");
             if(!FileMgr.OpenSdFile(FSEQFILELIST, c_FileMgr::FileMode::FileRead, FileHandle))
             {
                 logcon(F("ERROR: Could not open List of Fseq files for reading"));
@@ -665,6 +666,7 @@ size_t c_WebMgr::GetFseqFileListChunk(uint8_t *buffer, size_t maxlen, size_t ind
                 break;
             }
 
+            // DEBUG_V("Get the file size");
             TotalFileSizeToTransfer = FileMgr.GetSdFileSize(FileHandle);
         }
 
@@ -696,6 +698,7 @@ size_t c_WebMgr::GetFseqFileListChunk(uint8_t *buffer, size_t maxlen, size_t ind
             break;
         }
 
+        // DEBUG_V("Read a chunk");
         memset(buffer, 0x0, maxlen-1);
         FileMgr.ReadSdFile(FileHandle,
                            buffer,
@@ -703,7 +706,7 @@ size_t c_WebMgr::GetFseqFileListChunk(uint8_t *buffer, size_t maxlen, size_t ind
         // buffer[DataToSendThisChunk] = 'A';
         NumberOfBytesTransfered += DataToSendThisChunk;
         response = DataToSendThisChunk;
-        // DEBUG_VV(String("buffer: ") + String((char*)buffer));
+        // DEBUG_V(String("buffer: ") + String((char*)buffer));
 
     } while(false);
 

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_BreakDanceV2.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_BreakDanceV2.hpp
@@ -28,7 +28,7 @@
 #define SUPPORT_SPI_OUTPUT
 #define DEFAULT_SPI_DATA_GPIO   gpio_num_t::GPIO_NUM_27
 #define DEFAULT_SPI_CLOCK_GPIO  gpio_num_t::GPIO_NUM_32
-#define DEFAULT_SPI_DEVICE      HSPI_HOST
+#define DEFAULT_SPI_DEVICE      VSPI_HOST
 
 #define DEFAULT_I2C_SDA         gpio_num_t::GPIO_NUM_3
 #define DEFAULT_I2C_SCL         gpio_num_t::GPIO_NUM_5

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_D1_MINI.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_D1_MINI.hpp
@@ -30,7 +30,7 @@
 #define SUPPORT_SPI_OUTPUT
 #define DEFAULT_SPI_DATA_GPIO  gpio_num_t::GPIO_NUM_15
 #define DEFAULT_SPI_CLOCK_GPIO gpio_num_t::GPIO_NUM_25
-#define DEFAULT_SPI_DEVICE     HSPI_HOST
+#define DEFAULT_SPI_DEVICE     VSPI_HOST
 
 #define DEFAULT_I2C_SDA        gpio_num_t::GPIO_NUM_21
 #define DEFAULT_I2C_SCL        gpio_num_t::GPIO_NUM_22

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_D1_MINI_ETH.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_D1_MINI_ETH.hpp
@@ -41,7 +41,7 @@
 #define SUPPORT_SPI_OUTPUT
 #define DEFAULT_SPI_DATA_GPIO    gpio_num_t::GPIO_NUM_15
 #define DEFAULT_SPI_CLOCK_GPIO   gpio_num_t::GPIO_NUM_25
-#define DEFAULT_SPI_DEVICE       HSPI_HOST
+#define DEFAULT_SPI_DEVICE       VSPI_HOST
 
 #include <ETH.h>
 

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_DevkitC.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_DevkitC.hpp
@@ -31,7 +31,7 @@
 #define SUPPORT_SPI_OUTPUT
 #define DEFAULT_SPI_DATA_GPIO   gpio_num_t::GPIO_NUM_16
 #define DEFAULT_SPI_CLOCK_GPIO  gpio_num_t::GPIO_NUM_17
-#define DEFAULT_SPI_DEVICE      HSPI_HOST
+#define DEFAULT_SPI_DEVICE      VSPI_HOST
 
 #define DEFAULT_I2C_SDA         gpio_num_t::GPIO_NUM_3
 #define DEFAULT_I2C_SCL         gpio_num_t::GPIO_NUM_5

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_KA.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_KA.hpp
@@ -28,7 +28,7 @@
 #define SUPPORT_SPI_OUTPUT
 #define DEFAULT_SPI_DATA_GPIO  gpio_num_t::GPIO_NUM_15
 #define DEFAULT_SPI_CLOCK_GPIO gpio_num_t::GPIO_NUM_25
-#define DEFAULT_SPI_DEVICE     HSPI_HOST
+#define DEFAULT_SPI_DEVICE     VSPI_HOST
 
 #define DEFAULT_I2C_SDA        gpio_num_t::GPIO_NUM_21
 #define DEFAULT_I2C_SCL        gpio_num_t::GPIO_NUM_22

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_LoLin_D32_PRO.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_LoLin_D32_PRO.hpp
@@ -28,7 +28,7 @@
 #define SUPPORT_SPI_OUTPUT
 #define DEFAULT_SPI_DATA_GPIO   gpio_num_t::GPIO_NUM_27
 #define DEFAULT_SPI_CLOCK_GPIO  gpio_num_t::GPIO_NUM_32
-#define DEFAULT_SPI_DEVICE      HSPI_HOST
+#define DEFAULT_SPI_DEVICE      VSPI_HOST
 
 #define DEFAULT_I2C_SDA         gpio_num_t::GPIO_NUM_3
 #define DEFAULT_I2C_SCL         gpio_num_t::GPIO_NUM_5

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_MH_ET_LIVE_MiniKit.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_MH_ET_LIVE_MiniKit.hpp
@@ -33,7 +33,7 @@
 #define SUPPORT_SPI_OUTPUT
 #define DEFAULT_SPI_DATA_GPIO  gpio_num_t::GPIO_NUM_16
 #define DEFAULT_SPI_CLOCK_GPIO gpio_num_t::GPIO_NUM_17
-#define DEFAULT_SPI_DEVICE     HSPI_HOST
+#define DEFAULT_SPI_DEVICE     VSPI_HOST
 
 #define DEFAULT_I2C_SDA         gpio_num_t::GPIO_NUM_21
 #define DEFAULT_I2C_SCL         gpio_num_t::GPIO_NUM_22

--- a/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_Tetra2go.hpp
+++ b/ESPixelStick/src/platformDefinitions/GPIO_Defs_ESP32_Tetra2go.hpp
@@ -28,7 +28,7 @@
 #define SUPPORT_SPI_OUTPUT
 #define DEFAULT_SPI_DATA_GPIO   gpio_num_t::GPIO_NUM_15
 #define DEFAULT_SPI_CLOCK_GPIO  gpio_num_t::GPIO_NUM_25
-#define DEFAULT_SPI_DEVICE      HSPI_HOST
+#define DEFAULT_SPI_DEVICE      VSPI_HOST
 
 #define DEFAULT_I2C_SDA         gpio_num_t::GPIO_NUM_21
 #define DEFAULT_I2C_SCL         gpio_num_t::GPIO_NUM_22

--- a/platformio.ini
+++ b/platformio.ini
@@ -26,7 +26,7 @@ lib_deps =
     bblanchon/ArduinoJson @ 6.18.5
     djgrrr/Int64String @ 1.1.1
     https://github.com/esphome/ESPAsyncWebServer#4fd0a1fdf421664214a27373c0eb0247f94b7a79
-    https://github.com/MartinMueller2003/ESPAsyncE131
+    https://github.com/forkineye/ESPAsyncE131
     ottowinter/AsyncMqttClient-esphome @ 0.8.6
     https://github.com/MartinMueller2003/Artnet
     https://github.com/MartinMueller2003/Espalexa           ; pull latest

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,13 +31,20 @@ lib_deps =
     https://github.com/MartinMueller2003/Artnet
     https://github.com/MartinMueller2003/Espalexa           ; pull latest
     https://github.com/PaulStoffregen/Time
-    https://github.com/greiman/SdFat
+    https://github.com/greiman/SdFat @ 2.2.3
     https://github.com/MartinMueller2003/SimpleFTPServer
 extra_scripts =
     .scripts/download_fs.py
     .scripts/CopyTargets.py
     pre:.scripts/pio-version.py
 build_flags =
+;    -D ENABLE_DEDICATED_SPI=1 ; instruct SdFat to take ownership of the spi device
+    -D SDFAT_FILE_TYPE=3 ; SdFat full support
+    -D USE_LONG_FILE_NAMES=1 ; SdFat
+    -D MAINTAIN_FREE_CLUSTER_COUNT=1 ; SdFat
+    -D CHECK_FLASH_PROGRAMMING=0 ; SdFat
+    -D INCLUDE_SDIOS=1 ; SdFat
+;    -D USE_DBG_MACROS=2 ; SdFat
     -D SUPPORT_FTP
 ;    -D FTP_SERVER_DEBUG
 ;    -D FTP_ADDITIONAL_DEBUG


### PR DESCRIPTION
A change in the SD fat lib in June caused the builds to produce images that did not access the SD card. I have locked us to the most recent commit that works. 

SD is on HSPI. Moved SPI based pixels to VSPI