### PR TITLE
Fixed a number of issues with ESP8266 Boot failures.

### DIFF
--- a/.scripts/GetEthLibs.py
+++ b/.scripts/GetEthLibs.py
@@ -1,0 +1,20 @@
+import os
+
+Import("env")
+
+PROJECT_DIR = env['PROJECT_DIR']
+REPO_NAME   = "esp-eth-drivers"
+REPO_URL    = "https://github.com/espressif"
+LIBRARY_DIR = PROJECT_DIR + "/Libraries" + "/" + REPO_NAME
+
+print ("PROJECT_DIR:" + PROJECT_DIR)
+print ("LIBRARY_DIR:" + LIBRARY_DIR)
+print ("  REPO_NAME:" + REPO_NAME)
+print ("   REPO_URL:" + REPO_URL)
+
+if not os.path.exists(LIBRARY_DIR):
+    print ("Clone " + REPO_NAME + " Libray")
+    env.Execute("git clone --depth 100 " + REPO_URL + "/" + REPO_NAME + " " + LIBRARY_DIR )
+else:
+    print ("Pull " + REPO_NAME + " Libray")
+    env.Execute("git --work-tree=" + LIBRARY_DIR + " --git-dir=" + LIBRARY_DIR + "/.git pull origin master --depth 100")

--- a/html/index.html
+++ b/html/index.html
@@ -215,6 +215,10 @@
                                 <td width="33%">Errors: </td>
                                 <td><span id="ddperrors"></span></td>
                             </tr>
+                            <tr>
+                                <td width="50%">Last Error: </td>
+                                <td><span id="ddplasterror"></span></td>
+                            </tr>
                         </table>
                     </fieldset>
                 </div>

--- a/html/script.js
+++ b/html/script.js
@@ -2233,6 +2233,7 @@ function ProcessReceivedJsonStatusMessage(JsonStat) {
         $('#ddppacketsreceived').text(InputStatus.ddp.packetsreceived);
         $('#ddpbytesreceived').text(InputStatus.ddp.bytesreceived);
         $('#ddperrors').text(InputStatus.ddp.errors);
+        $('#ddplasterror').text(InputStatus.ddp.lasterror);
     }
     else {
         $('#ddpStatus').addClass("hidden")

--- a/html/script.js
+++ b/html/script.js
@@ -10,7 +10,7 @@ var System_Config = null;
 var Fseq_File_List = [];
 var selector = [];
 var target = document.location.host;
-target = "192.168.10.220";
+// target = "192.168.10.220";
 
 var SdCardIsInstalled = false;
 var FseqFileTransferStartTime = new Date();

--- a/include/FileMgr.hpp
+++ b/include/FileMgr.hpp
@@ -245,7 +245,9 @@ public: struct __attribute__((__packed__, aligned(4))) CSD {
     uint32_t    LastFileSent = 0;
     uint32_t    expectedIndex = 0;
 
-    bool SdAccessSemaphore = false;
+#ifdef ARDUINO_ARCH_ESP32
+    SemaphoreHandle_t SdAccessSemaphore = NULL;
+#endif // def ARDUINO_ARCH_ESP32
 
 protected:
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -75,7 +75,8 @@ platform = espressif8266 @ ^4.2.1 ; Arduino Core v3.0.2
 board_build.f_cpu = 160000000L
 board_build.filesystem = littlefs
 board_build.ldscript = eagle.flash.4m2m.ld
-; monitor_filters = esp8266_exception_decoder
+; build_type = debug
+; monitor_filters = esp8266_exception_decoder ; requires build_type = debug
 build_flags =
     ${env.build_flags}
     -D PIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH_LOW_FLASH

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,7 @@ framework = arduino
 monitor_speed = 115200
 upload_speed = 921600
 lib_compat_mode = strict
-build_type = debug
+; build_type = debug
 lib_deps =
     adafruit/Adafruit PWM Servo Driver Library @ ^2.4.0
     bblanchon/ArduinoJson @ ^7.3.0
@@ -60,7 +60,7 @@ build_flags =
     -mtext-section-literals
     -Wl,-Map=firmware.map
     -Wl,--cref
-    -fstack-protector-all
+;    -fstack-protector-all
 lib_ignore =
 	ESP Async WebServer	; force the use of the esphome version
 	AsyncTCP			; force the use of the esphome version

--- a/src/FileMgr.cpp
+++ b/src/FileMgr.cpp
@@ -733,6 +733,9 @@ bool c_FileMgr::SaveFlashFile(const String &FileName, JsonDocument &FileData)
 
     // delay(100);
     // DEBUG_V("");
+#ifdef ARDUINO_ARCH_ESP8266
+    LOG_PORT.print(' ');
+#endif // def ARDUINO_ARCH_ESP8266
 
     fs::File file = LittleFS.open(FileName.c_str(), "w");
     // DEBUG_V("");

--- a/src/FileMgr.cpp
+++ b/src/FileMgr.cpp
@@ -2060,7 +2060,6 @@ void c_FileMgr::BuildDefaultFseqList ()
     JsonWrite(jsonDoc, "totalBytes", 0);
     JsonWrite(jsonDoc, "usedBytes", 0);
     JsonWrite(jsonDoc, "numFiles", 0);
-    JsonArray jsonDocFileList = jsonDoc["files"].to<JsonArray> ();
     SaveFlashFile(FSEQFILELIST, jsonDoc);
 
     // DEBUG_END;

--- a/src/FileMgr.cpp
+++ b/src/FileMgr.cpp
@@ -2071,6 +2071,7 @@ void c_FileMgr::BuildDefaultFseqList ()
     JsonWrite(jsonDoc, "totalBytes", 0);
     JsonWrite(jsonDoc, "usedBytes", 0);
     JsonWrite(jsonDoc, "numFiles", 0);
+    jsonDoc["files"].to<JsonArray> ();
     SaveFlashFile(FSEQFILELIST, jsonDoc);
 
     // DEBUG_END;

--- a/src/FileMgr.cpp
+++ b/src/FileMgr.cpp
@@ -701,6 +701,9 @@ bool c_FileMgr::SaveFlashFile (const String& FileName, const char * FileData)
     }
     else
     {
+#ifdef ARDUINO_ARCH_ESP8266
+        LOG_PORT.print(' ');
+#endif // def ARDUINO_ARCH_ESP8266
         file.seek (0, SeekSet);
         file.print (FileData);
         file.close ();
@@ -741,6 +744,9 @@ bool c_FileMgr::SaveFlashFile(const String &FileName, JsonDocument &FileData)
     else
     {
         // DEBUG_V("");
+#ifdef ARDUINO_ARCH_ESP8266
+        LOG_PORT.print(' ');
+#endif // def ARDUINO_ARCH_ESP8266
         file.seek(0, SeekSet);
         // DEBUG_V("");
 

--- a/src/FileMgr.cpp
+++ b/src/FileMgr.cpp
@@ -2065,7 +2065,7 @@ void c_FileMgr::BuildDefaultFseqList ()
     // DEBUG_END;
 
     return;
-} // GetDefaultFseqFileList
+} // BuildDefaultFseqList
 
 //-----------------------------------------------------------------------------
 bool c_FileMgr::SeekSdFile(const FileId & FileHandle, uint64_t position, SeekMode Mode)

--- a/src/FileMgr.cpp
+++ b/src/FileMgr.cpp
@@ -133,7 +133,10 @@ void ftp_transferCallback(FtpTransferOperation ftpOperation, const char* name, u
 ///< Start up the driver and put it into a safe mode
 c_FileMgr::c_FileMgr ()
 {
-    SdAccessSemaphore = false;
+#ifdef ARDUINO_ARCH_ESP32
+    SdAccessSemaphore = xSemaphoreCreateBinary();
+    UnLockSd();
+#endif // def ARDUINO_ARCH_ESP32
 } // c_FileMgr
 
 //-----------------------------------------------------------------------------
@@ -345,6 +348,11 @@ void dateTime(uint16_t* date, uint16_t* time, uint8_t* ms10)
 void c_FileMgr::SetSpiIoPins ()
 {
     // DEBUG_START;
+
+#ifdef ARDUINO_ARCH_ESP8266
+    ESP.wdtDisable();
+#endif // def ARDUINO_ARCH_ESP8266
+
 #if defined (SUPPORT_SD) || defined(SUPPORT_SD_MMC)
     if (SdCardInstalled)
     {
@@ -457,6 +465,9 @@ void c_FileMgr::SetSpiIoPins ()
     SdCardInstalled = false;
 #endif // defined (SUPPORT_SD) || defined(SUPPORT_SD_MMC)
 
+#ifdef ARDUINO_ARCH_ESP8266
+    ESP.wdtEnable(uint32_t(0));
+#endif // def ARDUINO_ARCH_ESP8266
     // DEBUG_END;
 
 } // SetSpiIoPins
@@ -701,9 +712,6 @@ bool c_FileMgr::SaveFlashFile (const String& FileName, const char * FileData)
     }
     else
     {
-#ifdef ARDUINO_ARCH_ESP8266
-        LOG_PORT.print(' ');
-#endif // def ARDUINO_ARCH_ESP8266
         file.seek (0, SeekSet);
         file.print (FileData);
         file.close ();
@@ -733,9 +741,6 @@ bool c_FileMgr::SaveFlashFile(const String &FileName, JsonDocument &FileData)
 
     // delay(100);
     // DEBUG_V("");
-#ifdef ARDUINO_ARCH_ESP8266
-    LOG_PORT.print(' ');
-#endif // def ARDUINO_ARCH_ESP8266
 
     fs::File file = LittleFS.open(FileName.c_str(), "w");
     // DEBUG_V("");
@@ -747,9 +752,6 @@ bool c_FileMgr::SaveFlashFile(const String &FileName, JsonDocument &FileData)
     else
     {
         // DEBUG_V("");
-#ifdef ARDUINO_ARCH_ESP8266
-        LOG_PORT.print(' ');
-#endif // def ARDUINO_ARCH_ESP8266
         file.seek(0, SeekSet);
         // DEBUG_V("");
 
@@ -1624,7 +1626,7 @@ uint64_t c_FileMgr::WriteSdFile (const FileId& FileHandle, byte* FileData, uint6
         // DEBUG_V (String ("File.Handle: ") + String (FileList[FileListIndex].handle));
         LockSd();
         FileList[FileListIndex].fsFile.seek (StartingPosition);
-        LockSd();
+        UnLockSd();
         response = WriteSdFile (FileHandle, FileData, NumBytesToWrite, true);
     }
     else
@@ -2087,7 +2089,6 @@ bool c_FileMgr::SeekSdFile(const FileId & FileHandle, uint64_t position, SeekMod
 
     bool response = false;
     int FileListIndex;
-    LockSd();
     do // once
     {
         if (-1 == (FileListIndex = FileListFindSdFileHandle (FileHandle)))
@@ -2096,6 +2097,7 @@ bool c_FileMgr::SeekSdFile(const FileId & FileHandle, uint64_t position, SeekMod
             break;
         }
 
+        LockSd();
         switch(Mode)
         {
             case SeekMode::SeekSet:
@@ -2121,8 +2123,8 @@ bool c_FileMgr::SeekSdFile(const FileId & FileHandle, uint64_t position, SeekMod
                 break;
             }
         } // end switch mode
+        UnLockSd();
     } while(false);
-    UnLockSd();
 
     // DEBUG_END;
     return response;
@@ -2133,14 +2135,10 @@ bool c_FileMgr::SeekSdFile(const FileId & FileHandle, uint64_t position, SeekMod
 void c_FileMgr::LockSd()
 {
     // DEBUG_START;
-    // DEBUG_V(String("SdAccessSemaphore: ") + SdAccessSemaphore);
 
-    // wait to get access to the SD card
-    while(true == SdAccessSemaphore)
-    {
-        delay(10);
-    }
-    SdAccessSemaphore = true;
+#ifdef ARDUINO_ARCH_ESP32
+    xSemaphoreTake( SdAccessSemaphore, TickType_t(-1) );
+#endif // def ARDUINO_ARCH_ESP32
 
     // DEBUG_END;
 } // LockSd
@@ -2149,9 +2147,10 @@ void c_FileMgr::LockSd()
 void c_FileMgr::UnLockSd()
 {
     // DEBUG_START;
+#ifdef ARDUINO_ARCH_ESP32
+    xSemaphoreGive( SdAccessSemaphore );
+#endif // def ARDUINO_ARCH_ESP32
 
-    // DEBUG_V(String("SdAccessSemaphore: ") + SdAccessSemaphore);
-    SdAccessSemaphore = false;
     // DEBUG_END;
 } // UnLockSd
 

--- a/src/WebMgr.cpp
+++ b/src/WebMgr.cpp
@@ -728,17 +728,10 @@ void c_WebMgr::ProcessXJRequest (AsyncWebServerRequest* client)
     FileMgr.GetStatus (system);
     // DEBUG_V ("");
 
-    if(WebJsonDoc.overflowed())
-    {
-        logcon(F("ERROR: Status Doc is too small"));
-        client->send (401, CN_applicationSLASHjson, F("Internal Error. Status Buffer is too small."));
-    }
-    else
-    {
-        // DEBUG_V("Send XJ response");
-        serializeJson(WebJsonDoc, XjResult);
-        client->send (200, CN_applicationSLASHjson, XjResult);
-    }
+    // DEBUG_V("Send XJ response");
+    serializeJson(WebJsonDoc, XjResult);
+    client->send (200, CN_applicationSLASHjson, XjResult);
+
     // WebJsonDoc.clear();
     // DEBUG_END;
 

--- a/src/input/InputDDP.cpp
+++ b/src/input/InputDDP.cpp
@@ -97,7 +97,7 @@ void c_InputDDP::GetStatus (JsonObject& jsonStatus)
     JsonWrite(ddpStatus, F("bytesreceived"),  float(stats.bytesReceived) / 1024.0);
     JsonWrite(ddpStatus, CN_errors,           stats.errors);
     JsonWrite(ddpStatus, CN_id,               InputChannelId);
-    JsonWrite(ddpStatus, F("lastError"),      lastError);
+    JsonWrite(ddpStatus, F("lasterror"),      lastError);
 
     // DEBUG_END;
 

--- a/src/input/InputFPPRemote.cpp
+++ b/src/input/InputFPPRemote.cpp
@@ -95,7 +95,10 @@ void c_InputFPPRemote::GetStatus (JsonObject& jsonStatus)
     {
         JsonObject PlayerObjectStatus = LocalPlayerStatus[StatusType].to<JsonObject> ();
         JsonWrite(PlayerObjectStatus, CN_count, FilePlayCount);
-        pInputFPPRemotePlayItem->GetStatus (PlayerObjectStatus);
+        if(pInputFPPRemotePlayItem)
+        {
+            pInputFPPRemotePlayItem->GetStatus (PlayerObjectStatus);
+        }
     }
 
     else

--- a/src/input/InputFPPRemotePlayFile.cpp
+++ b/src/input/InputFPPRemotePlayFile.cpp
@@ -149,12 +149,12 @@ void c_InputFPPRemotePlayFile::GetStatus (JsonObject& JsonStatus)
 
     String temp = GetFileName ();
 
-    JsonWrite(JsonStatus, CN_current_sequence,  temp);
+    JsonWrite(JsonStatus, CN_current_sequence,  (!FileMgr.SdCardIsInstalled ()) ? F("No SD Installed") : temp);
     JsonWrite(JsonStatus, CN_playlist,          temp);
     JsonWrite(JsonStatus, CN_seconds_elapsed,   String (secs));
     JsonWrite(JsonStatus, CN_seconds_played,    String (secs));
     JsonWrite(JsonStatus, CN_seconds_remaining, String (secsRem));
-    JsonWrite(JsonStatus, CN_sequence_filename, temp);
+    JsonWrite(JsonStatus, CN_sequence_filename, (!FileMgr.SdCardIsInstalled ()) ? F("No SD Installed") : temp);
     JsonWrite(JsonStatus, F("PlayedFileCount"), PlayedFileCount);
 
     // After inserting the total seconds and total seconds remaining,
@@ -165,7 +165,7 @@ void c_InputFPPRemotePlayFile::GetStatus (JsonObject& JsonStatus)
     JsonWrite(JsonStatus, CN_time_elapsed,   buf);
     ESP_ERROR_CHECK(saferSecondsToFormattedMinutesAndSecondsString(buf, secsRem));
     JsonWrite(JsonStatus, CN_time_remaining, buf);
-    JsonWrite(JsonStatus, CN_errors,         LastFailedPlayStatusMsg);
+    JsonWrite(JsonStatus, CN_errors,         (!FileMgr.SdCardIsInstalled ()) ? F("No SD Installed") : LastFailedPlayStatusMsg);
 
     // xDEBUG_END;
 

--- a/src/output/OutputRelay.cpp
+++ b/src/output/OutputRelay.cpp
@@ -423,13 +423,16 @@ void c_OutputRelay::OutputValue(RelayChannel_t & currentRelay, uint8_t NewValue)
     else
     {
         uint8_t newOutputValue = (NewValue > currentRelay.OnOffTriggerLevel) ? currentRelay.OnValue : currentRelay.OffValue;
-        // DEBUG_V (String(" newOutputValue: ") + String(newOutputValue));
+        // DEBUG_V (String(" OnOffTriggerLevel: ") + String(currentRelay.OnOffTriggerLevel));
+        // DEBUG_V (String("    newOutputValue: ") + String(newOutputValue));
         if (newOutputValue != currentRelay.previousValue)
         {
             // DEBUG_V (String("OutputDataIndex: ") + String(currentRelay.ChannelIndex));
             // DEBUG_V("Write New Value");
-            // DEBUG_V (String(" newOutputValue: ") + String(newOutputValue));
-            // DEBUG_V (String("         GpioId: ") + String(currentRelay.GpioId));
+            // DEBUG_V (String("OnOffTriggerLevel: ") + String(currentRelay.OnOffTriggerLevel));
+            // DEBUG_V (String("         NewValue: ") + String(NewValue));
+            // DEBUG_V (String("   newOutputValue: ") + String(newOutputValue));
+            // DEBUG_V (String("           GpioId: ") + String(currentRelay.GpioId));
             digitalWrite (uint8_t(currentRelay.GpioId), newOutputValue);
             currentRelay.previousValue = newOutputValue;
         }

--- a/src/output/OutputRelay.cpp
+++ b/src/output/OutputRelay.cpp
@@ -385,7 +385,9 @@ uint32_t c_OutputRelay::Poll ()
     {
         // DEBUG_V (String("OutputDataIndex: ") + String(OutputDataIndex));
         // DEBUG_V (String("        Enabled: ") + String(currentRelay.Enabled));
-        if (currentRelay.Enabled && (gpio_num_t(-1) != currentRelay.GpioId))
+        if ((currentRelay.Enabled) &&
+            (gpio_num_t(-1) != currentRelay.GpioId) &&
+            (!currentRelay.httpEnabled))
         {
             OutputValue(currentRelay, pOutputBuffer[OutputDataIndex]);
         }
@@ -424,7 +426,7 @@ void c_OutputRelay::OutputValue(RelayChannel_t & currentRelay, uint8_t NewValue)
         // DEBUG_V (String(" newOutputValue: ") + String(newOutputValue));
         if (newOutputValue != currentRelay.previousValue)
         {
-            // DEBUG_V (String("OutputDataIndex: ") + String(OutputDataIndex));
+            // DEBUG_V (String("OutputDataIndex: ") + String(currentRelay.ChannelIndex));
             // DEBUG_V("Write New Value");
             // DEBUG_V (String(" newOutputValue: ") + String(newOutputValue));
             // DEBUG_V (String("         GpioId: ") + String(currentRelay.GpioId));

--- a/src/output/OutputRmt.cpp
+++ b/src/output/OutputRmt.cpp
@@ -247,7 +247,7 @@ void c_OutputRmt::Begin (OutputRmtConfig_t config, c_OutputCommon * _pParent )
         if(!SendFrameTaskHandle)
         {
             // DEBUG_V("Start SendFrameTask");
-            xTaskCreatePinnedToCore(RMT_Task, "RMT_Task", 4096, NULL, 5, &SendFrameTaskHandle, 0);
+            xTaskCreatePinnedToCore(RMT_Task, "RMT_Task", 4096, NULL, 5, &SendFrameTaskHandle, 1);
             vTaskPrioritySet(SendFrameTaskHandle, 5);
         }
         // DEBUG_V("Add this instance to the running list");

--- a/src/service/FPPDiscovery.cpp
+++ b/src/service/FPPDiscovery.cpp
@@ -204,6 +204,10 @@ void c_FPPDiscovery::GetStatus (JsonObject & jsonStatus)
         {
             InputFPPRemote->GetFppRemotePlayStatus (MyJsonStatus);
         }
+        else
+        {
+            JsonWrite(MyJsonStatus, CN_errors, F("No SD installed"));
+        }
     }
     else
     {


### PR DESCRIPTION
- While the checkin comments mention a hack, the "hack" code has been removed. The issue was the SPI layer code taking longer than the WD Timeout to decide that an SD card was not present. 
- Fixed issues with SD card going offline after some access collisions. 
- Fixed a crash and added messages to the FPP File play UI output when the SD card is removed during a reboot and the config expects it to be present.
- Updated DDP output to list the last error that was detected.
- Fixed relay issue that overwrote the HTTP output value with the value from the system buffer.