### PR TITLE
Fixed issue that caused xLights to crash while pushing config to ESPS

### DIFF
--- a/include/ESPixelStick.h
+++ b/include/ESPixelStick.h
@@ -83,10 +83,6 @@ bool    deserializeCore        (JsonObject & json);
 bool    dsDevice               (JsonObject & json);
 bool    dsNetwork              (JsonObject & json);
 
-#ifndef ESPS_VERSION
-    #define ESPS_VERSION "4.x-dev"
-#endif
-
 struct __attribute__((packed)) ConstConfig_t
 {
     const char key[32];

--- a/include/input/InputE131.hpp
+++ b/include/input/InputE131.hpp
@@ -30,6 +30,7 @@ class c_InputE131 : public c_InputCommon
 
     byte _e131[sizeof(ESPAsyncE131)];
     #define e131 static_cast<ESPAsyncE131>(*(&_e131[0]))
+    ESPAsyncE131 * pE131 = nullptr;
 
     // e131_packet_t packet;           ///< Packet buffer for parsing
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,7 +83,11 @@ static void _u0_putc(char c){
 ConstConfig_t ConstConfig =
 {
     "configFoundHere",
-    ESPS_VERSION,
+#ifdef ESPS_VERSION
+    STRING(ESPS_VERSION),
+#else
+    "4.x-dev",
+#endif // ESPS_VERSION,
     __DATE__ " - " __TIME__,
     "/config.json",
     1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,8 +83,8 @@ static void _u0_putc(char c){
 ConstConfig_t ConstConfig =
 {
     "configFoundHere",
-    ESPS_VERSION "\0",
-    __DATE__ " - " __TIME__ "\0",
+    ESPS_VERSION,
+    __DATE__ " - " __TIME__,
     "/config.json",
     1
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,8 +83,8 @@ static void _u0_putc(char c){
 ConstConfig_t ConstConfig =
 {
     "configFoundHere",
-    STRING (ESPS_VERSION),
-    STRING (__DATE__) " - " STRING(__TIME__),
+    ESPS_VERSION "\0",
+    __DATE__ " - " __TIME__ "\0",
     "/config.json",
     1
 };

--- a/src/service/FPPDiscovery.cpp
+++ b/src/service/FPPDiscovery.cpp
@@ -556,6 +556,9 @@ void c_FPPDiscovery::sendPingPacket (IPAddress destination)
     strcpy (packet.hardwareType, FPP_VARIANT_NAME.c_str());
     packet.ranges[0] = 0;
 
+    // DEBUG_V(String("packet.version: '") + String(packet.version) + "'");
+    // DEBUG_V(String("packet.versionMajor: ") + String(packet.versionMajor));
+    // DEBUG_V(String("packet.versionMinor: ") + String(packet.versionMinor));
     // DEBUG_V ("Send Ping to " + destination.toString());
     udp.writeTo (packet.raw, sizeof (packet), destination, FPP_DISCOVERY_PORT);
 
@@ -727,6 +730,7 @@ void c_FPPDiscovery::BuildFseqResponse (String fname, c_FileMgr::FileId fseqFile
         } // while there are headers to process
     } // there are headers to process
 
+    // PrettyPrint(JsonData, "BuildFseqResponse");
     serializeJson (JsonData, resp);
     // DEBUG_V (String ("resp: ") + resp);
 
@@ -1066,6 +1070,7 @@ void c_FPPDiscovery::GetSysInfoJSON (JsonObject & jsonResponse)
     JsonArray jsonResponseIpAddresses = jsonResponse[F ("IPS")].to<JsonArray> ();
     jsonResponseIpAddresses.add(WiFi.localIP ().toString ());
 
+    PrettyPrint(jsonResponse, "GetSysInfoJSON");
     // DEBUG_END;
 
 } // GetSysInfoJSON

--- a/src/service/FPPDiscovery.cpp
+++ b/src/service/FPPDiscovery.cpp
@@ -1070,7 +1070,7 @@ void c_FPPDiscovery::GetSysInfoJSON (JsonObject & jsonResponse)
     JsonArray jsonResponseIpAddresses = jsonResponse[F ("IPS")].to<JsonArray> ();
     jsonResponseIpAddresses.add(WiFi.localIP ().toString ());
 
-    PrettyPrint(jsonResponse, "GetSysInfoJSON");
+    // PrettyPrint(jsonResponse, "GetSysInfoJSON");
     // DEBUG_END;
 
 } // GetSysInfoJSON


### PR DESCRIPTION
Cleaned up the creation of the version string to remove extra ""
Another fix to get E1.31 stable.