### PR TITLE
Add ESP32-P4-ETH (Waveshare) support

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 
 # Changelog
 
+### Unreleased
+
+- Added support for the Waveshare ESP32-P4-ETH board (Ethernet-only, no WiFi radio). This build uses the pioarduino platform (arduino-esp32 v3.x / IDF 5.x) and the existing IDF 5.x RMT output driver.
+- Made the WiFi driver optional (`SUPPORT_WIFI`) so radio-less boards build Ethernet-only.
+
 ### 4.0-beta5
 
 Numerous fixes have occurred since beta4, most notably web frontend stability (websockets removed) and FPP / xLights compatibility and synchronization.  You will need to be on a current release of xLights in order for input/output uploading to work.  MacOS libraries for the flash tool have been updated as well, but you will still have to execute the flash tool from the command line and jump through Apple's security hoops to allow mklittlefs to run.  Numerous 3rd party ESP32 platforms have been added for those that like to roll their own controllers.

--- a/include/ESPixelStick.h
+++ b/include/ESPixelStick.h
@@ -32,6 +32,12 @@
 #	error "Unsupported CPU type"
 #endif
 
+// Most targets have a WiFi radio. Boards that do not (e.g. the ESP32-P4, which
+// has no native radio) define WIFI_NOT_SUPPORTED and build Ethernet-only.
+#ifndef WIFI_NOT_SUPPORTED
+#   define SUPPORT_WIFI
+#endif // ndef WIFI_NOT_SUPPORTED
+
 #ifdef BOARD_HAS_PSRAM
 #   error "PSRAM is not supported by ESPixelStick"
 #endif // def BOARD_HAS_PSRAM

--- a/include/GPIO_Defs.hpp
+++ b/include/GPIO_Defs.hpp
@@ -120,6 +120,8 @@
 #   include "platforms/GPIO_Defs_ESP32S3_FH4R2.hpp"
 #elif defined(BOARD_ESP32_RELAY_BOARD_X8)
 #   include "platforms/GPIO_Defs_ESP32_Relay_Board_x8.hpp"
+#elif defined(BOARD_ESP32_P4_ETH)
+#   include "platforms/GPIO_Defs_ESP32_P4_ETH.hpp"
 #elif defined (ARDUINO_ARCH_ESP32)
 #   include "platforms/GPIO_Defs_ESP32_generic.hpp"
 #elif defined (ARDUINO_ARCH_ESP8266)

--- a/include/RiscVCompat.h
+++ b/include/RiscVCompat.h
@@ -1,0 +1,41 @@
+#pragma once
+/*
+* RiscVCompat.h - Portability shim for ESP32 RISC-V targets
+*
+* Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+* Copyright (c) 2026 Shelby Merrick
+* http://www.forkineye.com
+*
+*  This program is provided free for you to use in any way that you wish,
+*  subject to the laws and regulations where you are using it.  Due diligence
+*  is strongly suggested before using this code.  Please give credit where due.
+*
+*  The Author makes no warranty of any kind, express or implied, with regard
+*  to this program or the documentation contained in this document.  The
+*  Author shall not be liable in any event for incidental or consequential
+*  damages in connection with, or arising out of, the furnishing, performance
+*  or use of these programs.
+*
+* ----------------------------------------------------------------------------
+* Some third party libraries (notably ESPAsyncE131's RingBuf.h) implement their
+* "atomic block" using the xtensa-only inline assembly instructions xt_rsil /
+* xt_wsr_ps whenever ARDUINO_ARCH_ESP32 is defined. Those instructions do not
+* exist on the RISC-V ESP32 parts (C3 / C5 / C6 / H2 / P4). The arduino-esp32
+* v2.x core used to provide compatible xt_rsil / xt_wsr_ps macros for RISC-V,
+* but the v3.x core (required for the ESP32-P4) no longer does, so the libraries
+* fall back to the broken xtensa path and fail to compile.
+*
+* This header restores portable equivalents with the same save/restore
+* semantics as rsil/wsr (raise the interrupt mask, returning the previous
+* state, then restore it) using the FreeRTOS primitives that exist on every
+* ESP32 port. It is force-included (-include) for RISC-V build environments so
+* that the unmodified upstream libraries continue to build.
+*/
+
+#if defined(ARDUINO_ARCH_ESP32) && !defined(__XTENSA__)
+#   ifndef xt_rsil
+#       include <freertos/FreeRTOS.h>
+#       define xt_rsil(level)    ((uint32_t)portSET_INTERRUPT_MASK_FROM_ISR())
+#       define xt_wsr_ps(state)  portCLEAR_INTERRUPT_MASK_FROM_ISR((UBaseType_t)(state))
+#   endif // ndef xt_rsil
+#endif // ESP32 RISC-V

--- a/include/platforms/GPIO_Defs_ESP32_P4_ETH.hpp
+++ b/include/platforms/GPIO_Defs_ESP32_P4_ETH.hpp
@@ -1,0 +1,113 @@
+#pragma once
+/*
+ * GPIO_Defs_ESP32_P4_ETH.hpp - Output Management class
+ *
+ * Project: ESPixelStick - An ESP8266 / ESP32 and E1.31 based pixel driver
+ * Copyright (c) 2021 - 2026 Shelby Merrick
+ * http://www.forkineye.com
+ *
+ *  This program is provided free for you to use in any way that you wish,
+ *  subject to the laws and regulations where you are using it.  Due diligence
+ *  is strongly suggested before using this code.  Please give credit where due.
+ *
+ *  The Author makes no warranty of any kind, express or implied, with regard
+ *  to this program or the documentation contained in this document.  The
+ *  Author shall not be liable in any event for incidental or consequential
+ *  damages in connection with, or arising out of, the furnishing, performance
+ *  or use of these programs.
+ *
+ * ----------------------------------------------------------------------------
+ * Waveshare ESP32-P4-ETH
+ *   - ESP32-P4 (dual core RISC-V). No native WiFi radio -> Ethernet only.
+ *   - 10/100 Ethernet via the internal EMAC and an IP101GR (IP101) RMII PHY.
+ *   - RMII data plane pins are fixed by the ESP32-P4 IO_MUX:
+ *       TXD0=34 TXD1=35 TX_EN=49 RXD0=30 RXD1=29 CRS_DV=28 REF_CLK=50
+ *     The arduino-esp32 v3.x ETH driver configures those automatically; we
+ *     only supply the routable control/clock signals below.
+ *   - The clock is supplied externally (REF_CLK in on GPIO50), so the clock
+ *     mode is EMAC_CLK_EXT_IN.
+ *
+ * Free header GPIOs used for outputs: 1,2,3,4,5,6,48 plus SPI on 20/26/22.
+ * (GPIO0 is a strapping / user-button pin and is intentionally avoided.)
+ * The onboard microSD slot (SDMMC on GPIO39-44) is left disabled for now,
+ * mirroring the other Ethernet board definitions.
+ */
+
+// Output Manager
+// The ESP32-P4 provides four RMT TX channels, so four serial (pixel) ports are
+// defined. Each can alternatively be driven as a relay output. An SPI port is
+// provided for clocked protocols (WS2801 / APA102).
+const OM_OutputPortDefinition_t OM_OutputPortDefinitions[] =
+{
+    {OM_PortId_t(0), OM_PortType_t::OM_SERIAL, {gpio_num_t::GPIO_NUM_1}},
+    {OM_PortId_t(0), OM_PortType_t::OM_RELAY,  {gpio_num_t::GPIO_NUM_1}},
+    {OM_PortId_t(1), OM_PortType_t::OM_SERIAL, {gpio_num_t::GPIO_NUM_2}},
+    {OM_PortId_t(1), OM_PortType_t::OM_RELAY,  {gpio_num_t::GPIO_NUM_2}},
+    {OM_PortId_t(2), OM_PortType_t::OM_SERIAL, {gpio_num_t::GPIO_NUM_3}},
+    {OM_PortId_t(2), OM_PortType_t::OM_RELAY,  {gpio_num_t::GPIO_NUM_3}},
+    {OM_PortId_t(3), OM_PortType_t::OM_SERIAL, {gpio_num_t::GPIO_NUM_4}},
+    {OM_PortId_t(3), OM_PortType_t::OM_RELAY,  {gpio_num_t::GPIO_NUM_4}},
+    {OM_PortId_t(4), OM_PortType_t::OM_SPI,    {gpio_num_t::GPIO_NUM_20, gpio_num_t::GPIO_NUM_26, gpio_num_t::GPIO_NUM_22}},
+};
+
+// File Manager
+// The onboard microSD slot uses the SDMMC bus and is not enabled by default.
+// #define SUPPORT_SD_MMC
+// #define SD_CARD_DATA_0          gpio_num_t::GPIO_NUM_39
+// #define SD_CARD_DATA_1          gpio_num_t::GPIO_NUM_40
+// #define SD_CARD_DATA_2          gpio_num_t::GPIO_NUM_41
+// #define SD_CARD_DATA_3          gpio_num_t::GPIO_NUM_42
+
+// SUPPORT_SD is left undefined so SD support is not built. FileMgr still
+// references these pin names for its member initializers, so define inert
+// placeholders (the SPI header pins) even though the SPI SD path is disabled.
+#define SD_CARD_MISO_PIN        gpio_num_t::GPIO_NUM_21
+#define SD_CARD_MOSI_PIN        gpio_num_t::GPIO_NUM_20
+#define SD_CARD_CLK_PIN         gpio_num_t::GPIO_NUM_26
+#define SD_CARD_CS_PIN          gpio_num_t::GPIO_NUM_22
+
+// This board has no WiFi radio, so the firmware is built Ethernet-only.
+// WIFI_NOT_SUPPORTED is supplied as a build flag (see platformio.ini) because
+// it must be visible before this platform header is reached in the include
+// graph (ESPixelStick.h consumes it to gate SUPPORT_WIFI).
+
+#define SUPPORT_ETHERNET
+#include <ETH.h>
+
+// PHY address of the IP101 on the RMII bus
+#define ETH_ADDR_PHY_IP101             1
+#define DEFAULT_ETH_ADDR               ETH_ADDR_PHY_IP101
+
+// Type of the Ethernet PHY. The IP101 family is selected via the TLK110 alias
+// in the arduino-esp32 ETH driver (ETH_PHY_IP101 maps to ETH_PHY_TLK110).
+#define DEFAULT_ETH_TYPE               eth_phy_type_t::ETH_PHY_TLK110
+
+// Management (MDIO) bus - routable control plane signals.
+#define DEFAULT_ETH_MDC_PIN            gpio_num_t::GPIO_NUM_31
+#define DEFAULT_ETH_MDIO_PIN           gpio_num_t::GPIO_NUM_52
+
+// PHY reset / power enable.
+#define DEFAULT_ETH_POWER_PIN          gpio_num_t::GPIO_NUM_51
+#define ETH_POWER_PIN                  DEFAULT_ETH_POWER_PIN
+#define DEFAULT_ETH_POWER_PIN_ACTIVE   HIGH
+
+// The 50MHz RMII reference clock is supplied externally (clock in).
+#define DEFAULT_ETH_CLK_MODE           eth_clock_mode_t::EMAC_CLK_EXT_IN
+
+// Output Types
+#define SUPPORT_OutputProtocol_TLS3001          // OM_SERIAL
+#define SUPPORT_OutputProtocol_APA102           // OM_SPI
+#define SUPPORT_OutputProtocol_DMX              // OM_SERIAL
+#define SUPPORT_OutputProtocol_GECE             // OM_SERIAL
+#define SUPPORT_OutputProtocol_GS8208           // OM_SERIAL
+#define SUPPORT_OutputProtocol_Renard           // OM_SERIAL
+#define SUPPORT_OutputProtocol_Serial           // OM_SERIAL
+#define SUPPORT_OutputProtocol_TM1814           // OM_SERIAL
+#define SUPPORT_OutputProtocol_UCS1903          // OM_SERIAL
+#define SUPPORT_OutputProtocol_UCS8903          // OM_SERIAL
+#define SUPPORT_OutputProtocol_WS2801           // OM_SPI
+#define SUPPORT_OutputProtocol_WS2811           // OM_SERIAL
+#define SUPPORT_OutputProtocol_Relay            // OM_RELAY
+#define SUPPORT_OutputProtocol_Servo_PCA9685    // OM_I2C
+#define SUPPORT_OutputProtocol_FireGod          // OM_SERIAL
+#define SUPPORT_OutputProtocol_GRINCH           // OM_SPI

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@
 ; Local configuration should be done in platformio_user.ini
 
 [platformio]
-default_envs = esp32_idftest, esp8266_espsv3, esp8266_wemos_d1_mini, esp8266_wemos_d1_mini_pro, esp8266_esp01s, esp32_lolin_d1_pro, esp32_lolin_d1_pro_eth, esp32_cam, esp32_ttgo_t8, esp32_bong69, esp32_wt32eth01, esp32_quinled_quad, esp32_quinled_quad_p5, esp32_quinled_quad_ae_plus, esp32_quinled_quad_ae_plus_8, esp32_quinled_quad_eth, esp32_quinled_quad_eth_p5, esp32_quinled_uno, esp32_quinled_uno_ae_plus, esp32_quinled_uno_eth, esp32_quinled_dig_octa, esp32_d1_mini_mhetesp32minikit, esp32_olimex_gw, esp32_d1_mini_twilightlord, esp32_d1_mini_twilightlord_eth, esp32_devkitc, esp32_devkitc6, esp32_quinled_uno_eth_espsv3, esp32_quinled_uno_espsv3, esp32_m5stack_atom, esp32_deuxquatro_dmx, esp32_wasatch, esp32_tetra2go, esp32_octa2go, esp32_solo2go, esp32_kr_lights_msm, esp32_ka, esp32_ka_4, esp32_breakdancev2, esp32_foo, esp32s3_seeed_xiao, esp32_wemos_d1_mini32, esp32_wemos_d1_mini32_eth, esp32s3_devkitc, esp32s3_devkitc_Internal_SD, esp32_devkitv_eth, esp32s3_fh4r2, esp32_relayboardx8
+default_envs = esp32_idftest, esp8266_espsv3, esp8266_wemos_d1_mini, esp8266_wemos_d1_mini_pro, esp8266_esp01s, esp32_lolin_d1_pro, esp32_lolin_d1_pro_eth, esp32_cam, esp32_ttgo_t8, esp32_bong69, esp32_wt32eth01, esp32_quinled_quad, esp32_quinled_quad_p5, esp32_quinled_quad_ae_plus, esp32_quinled_quad_ae_plus_8, esp32_quinled_quad_eth, esp32_quinled_quad_eth_p5, esp32_quinled_uno, esp32_quinled_uno_ae_plus, esp32_quinled_uno_eth, esp32_quinled_dig_octa, esp32_d1_mini_mhetesp32minikit, esp32_olimex_gw, esp32_d1_mini_twilightlord, esp32_d1_mini_twilightlord_eth, esp32_devkitc, esp32_devkitc6, esp32_quinled_uno_eth_espsv3, esp32_quinled_uno_espsv3, esp32_m5stack_atom, esp32_deuxquatro_dmx, esp32_wasatch, esp32_tetra2go, esp32_octa2go, esp32_solo2go, esp32_kr_lights_msm, esp32_ka, esp32_ka_4, esp32_breakdancev2, esp32_foo, esp32s3_seeed_xiao, esp32_wemos_d1_mini32, esp32_wemos_d1_mini32_eth, esp32s3_devkitc, esp32s3_devkitc_Internal_SD, esp32_devkitv_eth, esp32s3_fh4r2, esp32_relayboardx8, esp32_p4_eth
 ;default_envs = esp32_idftest
 
 src_dir = ./src
@@ -206,6 +206,26 @@ lib_ignore =
 
 extra_scripts = ${env.extra_scripts}
     .scripts/replace_fs.py
+
+;~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~;
+; ESP32-P4 (RISC-V) defaults                                          ;
+; The official espressif32 platform does not support the ESP32-P4.    ;
+; Use the community pioarduino fork (arduino-esp32 v3.x / IDF 5.x).    ;
+;~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~;
+[esp32p4]
+extends = esp32
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+build_unflags =
+    ${esp32.build_unflags}
+    ; xtensa-only assembler option, invalid for the RISC-V toolchain
+    -mtext-section-literals
+lib_ignore =
+    ${esp32.lib_ignore}
+    ; OneWire's direct GPIO register access does not compile on the ESP32-P4
+    ; (RISC-V) yet; the DS18B20 sensor that uses it is not enabled on this
+    ; platform, so exclude both from the build.
+    OneWire
+    DS18B20
 
 ;~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~;
 ; Build targets (environments) ;
@@ -735,3 +755,23 @@ build_flags =
 lib_compat_mode = strict
 build_unflags =
     ${esp32.build_unflags}
+
+; Waveshare ESP32-P4-ETH (Ethernet only, no WiFi radio)
+[env:esp32_p4_eth]
+extends = esp32p4
+board = esp32-p4-evboard
+build_flags =
+    ${esp32.build_flags}
+    -D BOARD_NAME='"esp32 p4 eth"'
+    -D BOARD_ESP32_P4_ETH
+    -D WIFI_NOT_SUPPORTED
+    ; RISC-V parts need portable xt_rsil/xt_wsr_ps for some libraries (see header)
+    -include RiscVCompat.h
+build_unflags =
+    ${esp32p4.build_unflags}
+; The register-level UART output backends do not build on the ESP32-P4. The P4
+; uses the RMT backends for both pixel and serial (DMX/Renard) protocols, so the
+; UART output sources are excluded from this build.
+build_src_filter =
+    +<*>
+    -<output/*Uart.cpp>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,7 +58,11 @@ extern "C"
 #   include <Update.h>
 #   include <esp_task_wdt.h>
 #   include "soc/soc.h"
-#   include "soc/rtc_cntl_reg.h"
+    // The RTC control register layout differs on the ESP32-P4; this header is
+    // absent there, so only pull it in when it actually exists.
+#   if !defined(__has_include) || __has_include("soc/rtc_cntl_reg.h")
+#       include "soc/rtc_cntl_reg.h"
+#   endif
 #else
 #	error "Unsupported CPU type."
 #endif
@@ -176,8 +180,11 @@ void setup()
 
     config.BlankDelay = 5;
 #ifdef ARDUINO_ARCH_ESP32
-    // disable brownout detector
+    // disable brownout detector (the register is named differently on the
+    // ESP32-P4, where this workaround is simply skipped)
+#ifdef RTC_CNTL_BROWN_OUT_REG
     WRITE_PERI_REG(RTC_CNTL_BROWN_OUT_REG, 0);
+#endif // def RTC_CNTL_BROWN_OUT_REG
     heap_caps_register_failed_alloc_callback(esp_alloc_failed_hook_callback);
 #endif // def ARDUINO_ARCH_ESP32
 
@@ -696,7 +703,11 @@ void _logcon (String & DriverName, String Message)
 
 #ifdef ARDUINO_ARCH_ESP32
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
-#include <rtc_wdt.h>
+    // The ESP32-P4 uses a different (LP) watchdog API and does not declare the
+    // rtc_wdt_* helpers, so this header / those calls are skipped there.
+#   if !defined(CONFIG_IDF_TARGET_ESP32P4)
+#       include <rtc_wdt.h>
+#   endif // !defined(CONFIG_IDF_TARGET_ESP32P4)
 #endif // ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 #endif // def ARDUINO_ARCH_ESP32
 
@@ -705,8 +716,10 @@ void FeedWDT ()
 #ifdef ARDUINO_ARCH_ESP32
     #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
         // esp_task_wdt_reset ();
+        #if !defined(CONFIG_IDF_TARGET_ESP32P4)
         rtc_wdt_protect_off();
         rtc_wdt_disable();
+        #endif // rtc_wdt_* are not provided on the ESP32-P4
         esp_task_wdt_deinit();
     #else
         esp_task_wdt_reset ();

--- a/src/network/NetworkMgr.cpp
+++ b/src/network/NetworkMgr.cpp
@@ -84,7 +84,9 @@ void c_NetworkMgr::Begin ()
     // Make sure the local config is valid
     Validate ();
 
+#ifdef SUPPORT_WIFI
     WiFiDriver.Begin ();
+#endif // def SUPPORT_WIFI
 
 #ifdef SUPPORT_ETHERNET
     EthernetDriver.Begin ();
@@ -103,8 +105,10 @@ void c_NetworkMgr::GetConfig (JsonObject & json)
 
     JsonWrite(NetworkConfig, CN_hostname, hostname);
 
+#ifdef SUPPORT_WIFI
     JsonObject NetworkWiFiConfig = NetworkConfig[(char*)CN_wifi].to<JsonObject> ();
     WiFiDriver.GetConfig (NetworkWiFiConfig);
+#endif // def SUPPORT_WIFI
 
 #ifdef SUPPORT_ETHERNET
     JsonWrite(NetworkConfig, CN_weus, AllowWiFiAndEthUpSimultaneously);
@@ -120,7 +124,26 @@ void c_NetworkMgr::GetConfig (JsonObject & json)
 //-----------------------------------------------------------------------------
 IPAddress c_NetworkMgr::GetlocalIP ()
 {
+#ifdef SUPPORT_WIFI
+    if (IsWiFiConnected)
+    {
+        return WiFiDriver.getIpAddress();
+    }
+#endif // def SUPPORT_WIFI
+
+#ifdef SUPPORT_ETHERNET
+    if (IsEthernetConnected)
+    {
+        return EthernetDriver.GetIpAddress();
+    }
+#endif // def SUPPORT_ETHERNET
+
+#ifdef SUPPORT_WIFI
+    // Not connected: fall back to whatever the WiFi driver reports (AP IP etc.)
     return WiFiDriver.getIpAddress();
+#else
+    return IPAddress(INADDR_NONE);
+#endif // def SUPPORT_WIFI
 } // GetlocalIP
 
 //-----------------------------------------------------------------------------
@@ -133,8 +156,10 @@ void c_NetworkMgr::GetStatus (JsonObject & json)
     GetHostname (name);
     JsonWrite(NetworkStatus, CN_hostname, name);
 
+#ifdef SUPPORT_WIFI
     JsonObject NetworkWiFiStatus = NetworkStatus[(char*)CN_wifi].to<JsonObject> ();
     WiFiDriver.GetStatus (NetworkWiFiStatus);
+#endif // def SUPPORT_WIFI
 
 #ifdef SUPPORT_ETHERNET
     JsonObject NetworkEthStatus = NetworkStatus[(char*)CN_eth].to<JsonObject> ();
@@ -152,7 +177,9 @@ void c_NetworkMgr::Poll ()
 
     do // once
     {
+#ifdef SUPPORT_WIFI
         WiFiDriver.Poll ();
+#endif // def SUPPORT_WIFI
 
 #ifdef SUPPORT_ETHERNET
         EthernetDriver.Poll ();
@@ -185,6 +212,7 @@ bool c_NetworkMgr::SetConfig (JsonObject & json)
         HostnameChanged = setFromJSON (hostname, network, CN_hostname);
         // DEBUG_V("");
 
+#ifdef SUPPORT_WIFI
         JsonObject networkWiFi = network[(char*)CN_wifi];
         if (networkWiFi)
         {
@@ -208,6 +236,7 @@ bool c_NetworkMgr::SetConfig (JsonObject & json)
                 logcon (String (F ("No network WiFi settings found. Using default WiFi Settings")));
             }
         }
+#endif // def SUPPORT_WIFI
 
 #ifdef SUPPORT_ETHERNET
         ConfigChanged = setFromJSON (AllowWiFiAndEthUpSimultaneously, network, CN_weus);
@@ -238,7 +267,9 @@ bool c_NetworkMgr::SetConfig (JsonObject & json)
     {
         // DEBUG_V(String("hostname: ") + hostname);
         String temp = String(hostname);
+#ifdef SUPPORT_WIFI
         WiFiDriver.SetHostname (temp);
+#endif // def SUPPORT_WIFI
 #ifdef SUPPORT_ETHERNET
         EthernetDriver.SetHostname (temp);
 #endif // def SUPPORT_ETHERNET
@@ -297,6 +328,7 @@ void c_NetworkMgr::SetWiFiEnable ()
 {
     // DEBUG_START;
 
+#ifdef SUPPORT_WIFI
     if (!AllowWiFiAndEthUpSimultaneously)
     {
         // DEBUG_V ("!AllowWiFiAndEthUpSimultaneously");
@@ -316,6 +348,7 @@ void c_NetworkMgr::SetWiFiEnable ()
         // DEBUG_V ("AllowWiFiAndEthUpSimultaneously");
         WiFiDriver.Enable ();
     }
+#endif // def SUPPORT_WIFI
     // DEBUG_END;
 
 } // SetWiFiEnabled


### PR DESCRIPTION
Adds an Ethernet-only build target for the Waveshare ESP32-P4-ETH board on the pioarduino platform (arduino-esp32 v3.x / IDF 5.x).

- New board definition GPIO_Defs_ESP32_P4_ETH.hpp (internal EMAC + IP101 PHY, external clock-in; 4 RMT pixel ports + 1 SPI port).
- New RMT output driver built on the IDF 5.x driver/rmt_tx + a custom pull-based encoder, gated to CONFIG_IDF_TARGET_ESP32P4. Existing ESP32/S2/S3 targets keep the original register-level RMT driver unchanged.
- WiFi made optional (SUPPORT_WIFI) so radio-less boards build Ethernet-only.
- EthernetDriver ETH.begin() version-guarded for the arduino-esp32 v3.x API.
- main.cpp brownout-register access guarded (renamed on the P4).
- RiscVCompat.h restores xt_rsil/xt_wsr_ps for ESP32 RISC-V so unmodified libraries (ESPAsyncE131) compile.
- platformio.ini: [esp32p4] base + [env:esp32_p4_eth]; drop xtensa-only -mtext-section-literals, ignore OneWire/DS18B20, and exclude the register-level UART output backends (the P4 uses RMT for serial protocols).

Builds clean for esp32_p4_eth; esp32_devkitc and esp32s3_devkitc verified unaffected.